### PR TITLE
Fix autocomplete issue when removing chars

### DIFF
--- a/lib/elixir_console_web/live/console_live.ex
+++ b/lib/elixir_console_web/live/console_live.ex
@@ -156,7 +156,7 @@ defmodule ElixirConsoleWeb.ConsoleLive do
   end
 
   def handle_event("suggest", _key, socket) do
-    {:noreply, socket |> assign(history_counter: -1)}
+    {:noreply, socket |> assign(history_counter: -1, input_value: "")}
   end
 
   def handle_event("execute", %{"command" => command}, socket) do

--- a/lib/elixir_console_web/live/console_live.ex
+++ b/lib/elixir_console_web/live/console_live.ex
@@ -103,7 +103,7 @@ defmodule ElixirConsoleWeb.ConsoleLive do
     bindings_names = Enum.map(bindings, fn {name, _} -> Atom.to_string(name) end)
     all_names = bindings_names ++ Documentation.get_functions_names()
 
-    suggestions = Enum.filter(all_names, &String.starts_with?(&1, last_word))
+    suggestions = Enum.filter(all_names, &String.starts_with?(&1, last_word)) |> Enum.sort()
 
     case suggestions do
       [suggestion] ->

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -56,4 +56,23 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
                  "Not allowed modules attempted: [:Code, :File]"
     end
   end
+
+  describe "autocomplete" do
+    test "show suggestions if more than one", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+      html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.co"})
+
+      assert html =~ ~r/Suggestions\:.*Enum\.concat.*Enum\.count/
+    end
+
+    test "autocomplete and do not show suggestions if only one", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+      html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.conc"})
+
+      assert html =~ ~r/\<input .* data-input_value\="Enum.concat"/
+
+      refute html =~ ~r/Suggestions\:.*Enum\.concat/
+      assert html =~ "INSTRUCTIONS"
+    end
+  end
 end

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -46,15 +46,14 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       assert html =~
                "%UndefinedFunctionError{arity: 1, function: :foo, message: nil, module: Enum, reason: nil}"
     end
-  end
 
-  test "send a command with invalid modules", %{conn: conn} do
-    {:ok, view, _html} = live(conn, "/")
+    test "send a command with invalid modules", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+      html = render_submit(view, "execute", %{"command" => "File.exists?(Code.get_docs())"})
 
-    html = render_submit(view, "execute", %{"command" => "File.exists?(Code.get_docs())"})
-
-    assert html =~
-             "It is not allowed to use some Elixir modules. " <>
-               "Not allowed modules attempted: [:Code, :File]"
+      assert html =~
+               "It is not allowed to use some Elixir modules. " <>
+                 "Not allowed modules attempted: [:Code, :File]"
+    end
   end
 end


### PR DESCRIPTION
## Steps to reproduce

- Write "Enum.coun" in the command input
- Press TAB key, so it is autocompleted to "Enum.count"
- Then delete the last letter, so it reads "Enum.coun" again.
- Press Tab key again

## Expected result

The input value is autocompleted to "Enum.count" again.

## Actual result

The input value is not changed.