### PR TITLE
Autocomplete from caret position

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,7 +1,7 @@
 // We need to import the CSS so that webpack will load it.
 // The MiniCssExtractPlugin is used to separate it out into
 // its own CSS file.
-import css from "../css/app.css"
+import css from '../css/app.css';
 
 // webpack automatically bundles all modules in your
 // entry points. Those entry points can be configured
@@ -9,45 +9,45 @@ import css from "../css/app.css"
 //
 // Import dependencies
 //
-import "phoenix_html"
+import 'phoenix_html';
 
 // Import local files
 //
 // Local files can be imported directly using relative paths, for example:
 // import socket from "./socket"
 
-import {Socket} from "phoenix"
-import LiveSocket from "phoenix_live_view"
+import {Socket} from 'phoenix';
+import LiveSocket from 'phoenix_live_view';
 
-let Hooks = {}
+let Hooks = {};
 Hooks.CommandInput = {
   mounted() {
     const pushEvent = this.pushEvent;
-    const input = document.getElementById("commandInput");
+    const input = document.getElementById('commandInput');
     const sendCursorPosition = e => {
       if (input.selectionStart === input.selectionEnd) {
-        this.pushEvent("caret-position", { position: input.selectionEnd });
+        this.pushEvent('caret-position', { position: input.selectionEnd });
       }
     };
 
-    ["keyup", "click", "focus"].forEach(event => {
+    ['keyup', 'click', 'focus'].forEach(event => {
       input.addEventListener(event, sendCursorPosition, true);
-    })
+    });
   },
   updated() {
-    let newValue = this.el.getAttribute("data-input_value")
-    if (newValue !== "") {
+    let newValue = this.el.getAttribute('data-input_value');
+    if (newValue !== '') {
       this.el.value = newValue;
     }
   }
 }
 
-let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks})
-liveSocket.connect()
+let liveSocket = new LiveSocket('/live', Socket, {hooks: Hooks});
+liveSocket.connect();
 
-document.addEventListener("DOMContentLoaded", function(event) {
-  let input = document.getElementById("commandInput");
-  input.addEventListener("keydown", function(e) {
+document.addEventListener('DOMContentLoaded', function(event) {
+  let input = document.getElementById('commandInput');
+  input.addEventListener('keydown', function(e) {
     if (e.keyCode === 9) {
       e.preventDefault();
     }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,6 +21,19 @@ import LiveSocket from "phoenix_live_view"
 
 let Hooks = {}
 Hooks.CommandInput = {
+  mounted() {
+    const pushEvent = this.pushEvent;
+    const input = document.getElementById("commandInput");
+    const sendCursorPosition = e => {
+      if (input.selectionStart === input.selectionEnd) {
+        this.pushEvent("caret-position", { position: input.selectionEnd });
+      }
+    };
+
+    ["keyup", "click", "focus"].forEach(event => {
+      input.addEventListener(event, sendCursorPosition, true);
+    })
+  },
   updated() {
     let newValue = this.el.getAttribute("data-input_value")
     if (newValue !== "") {

--- a/lib/elixir_console/autocomplete.ex
+++ b/lib/elixir_console/autocomplete.ex
@@ -1,0 +1,45 @@
+defmodule ElixirConsole.Autocomplete do
+  @moduledoc """
+  Encapsulates all the logic related with the autocomplete feature
+  """
+
+  alias ElixirConsole.Documentation
+
+  @doc """
+  Get a list of suggestions with all the possible words that could fit in the
+  command that is being typed by the user.
+  """
+  def get_suggestions(value, caret_position, bindings) do
+    word_to_autocomplete = word_to_autocomplete(value, caret_position)
+
+    bindings_names = Enum.map(bindings, fn {name, _} -> Atom.to_string(name) end)
+    all_names = bindings_names ++ Documentation.get_functions_names()
+
+    all_names
+    |> Enum.filter(&String.starts_with?(&1, word_to_autocomplete))
+    |> Enum.sort()
+    |> Enum.take(10)
+  end
+
+  @doc """
+  Returns a modified version of the command input value with an autocompleted word.
+  It means that the `suggestion` value is used to replace the word that ends in the
+  `caret_position` position of the provided `value`
+  """
+  def autocompleted_input(value, caret_position, suggestion) do
+    word_to_autocomplete = word_to_autocomplete(value, caret_position)
+    {value_until_caret, value_from_caret} = split_command_for_autocomplete(value, caret_position)
+
+    Regex.replace(~r/\.*#{word_to_autocomplete}$/, value_until_caret, suggestion) <>
+      value_from_caret
+  end
+
+  defp word_to_autocomplete(value, caret_position) do
+    {value_until_caret, _} = split_command_for_autocomplete(value, caret_position)
+    value_until_caret |> String.split() |> List.last() || ""
+  end
+
+  defp split_command_for_autocomplete(value, caret_position) do
+    {String.slice(value, 0, caret_position), String.slice(value, caret_position, 10_000)}
+  end
+end

--- a/lib/elixir_console/autocomplete.ex
+++ b/lib/elixir_console/autocomplete.ex
@@ -5,6 +5,8 @@ defmodule ElixirConsole.Autocomplete do
 
   alias ElixirConsole.Documentation
 
+  @max_command_length 10_000
+
   @doc """
   Get a list of suggestions with all the possible words that could fit in the
   command that is being typed by the user.
@@ -40,6 +42,7 @@ defmodule ElixirConsole.Autocomplete do
   end
 
   defp split_command_for_autocomplete(value, caret_position) do
-    {String.slice(value, 0, caret_position), String.slice(value, caret_position, 10_000)}
+    {String.slice(value, 0, caret_position),
+     String.slice(value, caret_position, @max_command_length)}
   end
 end

--- a/lib/elixir_console_web/live/console_live.ex
+++ b/lib/elixir_console_web/live/console_live.ex
@@ -103,14 +103,13 @@ defmodule ElixirConsoleWeb.ConsoleLive do
     case Autocomplete.get_suggestions(value, caret_position, bindings) do
       [suggestion] ->
         {:noreply,
-         socket
-         |> assign(
+         assign(socket,
            suggestions: [],
            input_value: Autocomplete.autocompleted_input(value, caret_position, suggestion)
          )}
 
       suggestions ->
-        {:noreply, socket |> assign(suggestions: suggestions, input_value: "")}
+        {:noreply, assign(socket, suggestions: suggestions, input_value: "")}
     end
   end
 
@@ -131,7 +130,7 @@ defmodule ElixirConsoleWeb.ConsoleLive do
           {[List.last(history)], counter}
       end
 
-    {:noreply, socket |> assign(input_value: input_value, history_counter: new_counter)}
+    {:noreply, assign(socket, input_value: input_value, history_counter: new_counter)}
   end
 
   # KEY DOWN
@@ -151,15 +150,15 @@ defmodule ElixirConsoleWeb.ConsoleLive do
           {[List.first(history)], 0}
       end
 
-    {:noreply, socket |> assign(input_value: input_value, history_counter: new_counter)}
+    {:noreply, assign(socket, input_value: input_value, history_counter: new_counter)}
   end
 
   def handle_event("suggest", _key, socket) do
-    {:noreply, socket |> assign(history_counter: -1, input_value: "")}
+    {:noreply, assign(socket, history_counter: -1, input_value: "")}
   end
 
   def handle_event("caret-position", %{"position" => position}, socket) do
-    {:noreply, socket |> assign(caret_position: position)}
+    {:noreply, assign(socket, caret_position: position)}
   end
 
   def handle_event("execute", %{"command" => command}, socket) do

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -56,4 +56,23 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
                  "Not allowed modules attempted: [:Code, :File]"
     end
   end
+
+  describe "autocomplete" do
+    test "show suggestions if more than one", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+      html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.co"})
+
+      assert html =~ ~r/Suggestions\:.*Enum\.concat.*Enum\.count/
+    end
+
+    test "autocomplete and do not show suggestions if only one", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+      html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.conc"})
+
+      assert html =~ ~r/\<input .* data-input_value\="Enum.concat"/
+
+      refute html =~ ~r/Suggestions\:.*Enum\.concat/
+      assert html =~ "INSTRUCTIONS"
+    end
+  end
 end

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -2,6 +2,24 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
   use ElixirConsoleWeb.ConnCase
   import Phoenix.LiveViewTest
 
+  # Code based on https://github.com/phoenixframework/phoenix_live_view/blob/bba042ed6a6efa45f56b30c4d26fda7a0bdb8991/lib/phoenix_live_view/test/live_view_test.ex#L459
+  # because LiveViewTest module does not have a public "render_hook" function yet.
+  # Let's remove this when this method is available.
+  alias Phoenix.LiveViewTest.View
+
+  def render_event([%View{} = view | path], type, event, value) do
+    case GenServer.call(
+           proxy_pid(view),
+           {:render_event, proxy_topic(view), type, path, event, value}
+         ) do
+      {:ok, html} -> html
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp proxy_pid(%View{proxy: {_ref, _topic, pid}}), do: pid
+  defp proxy_topic(%View{proxy: {_ref, topic, _pid}}), do: topic
+
   describe "sending valid commands" do
     def render_with_valid_command(%{conn: conn}) do
       {:ok, view, _html} = live(conn, "/")
@@ -60,6 +78,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
   describe "autocomplete" do
     test "show suggestions if more than one", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/")
+      _ = render_event([view], :hook, :"caret-position", %{"position" => 7})
       html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.co"})
 
       assert html =~ ~r/Suggestions\:.*Enum\.concat.*Enum\.count/
@@ -67,9 +86,33 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
 
     test "autocomplete and do not show suggestions if only one", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/")
+      _ = render_event([view], :hook, :"caret-position", %{"position" => 9})
       html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.conc"})
 
       assert html =~ ~r/\<input .* data-input_value\="Enum.concat"/
+
+      refute html =~ ~r/Suggestions\:.*Enum\.concat/
+      assert html =~ "INSTRUCTIONS"
+    end
+
+    test "show suggestions considering caret position in the command input", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+
+      _ = render_event([view], :hook, :"caret-position", %{"position" => 7})
+      html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.co([1,2]) - 2"})
+
+      assert html =~ ~r/Suggestions\:.*Enum\.concat.*Enum\.count/
+    end
+
+    test "autocomplete considering caret position in the command input", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+
+      _ = render_event([view], :hook, :"caret-position", %{"position" => 9})
+
+      html =
+        render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.conc([1,2], [3])"})
+
+      assert html =~ ~r/\<input .* data-input_value\="Enum.concat\(\[1,2\], \[3\]\)"/
 
       refute html =~ ~r/Suggestions\:.*Enum\.concat/
       assert html =~ "INSTRUCTIONS"

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -56,23 +56,4 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
                  "Not allowed modules attempted: [:Code, :File]"
     end
   end
-
-  describe "autocomplete" do
-    test "show suggestions if more than one", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/")
-      html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.co"})
-
-      assert html =~ ~r/Suggestions\:.*Enum\.concat.*Enum\.count/
-    end
-
-    test "autocomplete and do not show suggestions if only one", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/")
-      html = render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.conc"})
-
-      assert html =~ ~r/\<input .* data-input_value\="Enum.concat"/
-
-      refute html =~ ~r/Suggestions\:.*Enum\.concat/
-      assert html =~ "INSTRUCTIONS"
-    end
-  end
 end


### PR DESCRIPTION
![autocomplete in the middle](https://user-images.githubusercontent.com/487140/69077716-fbe60180-0a14-11ea-8be5-001db7561e80.gif)

Note that this specific issue is going to be tackled afterwards: https://app.clubhouse.io/wyeworks/story/74/autocomplete-from-the-middle-should-preserve-cursor-position