### PR TITLE
Restore cursor position after autocomplete

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -35,9 +35,12 @@ Hooks.CommandInput = {
     });
   },
   updated() {
-    let newValue = this.el.getAttribute('data-input_value');
+    const newValue = this.el.getAttribute('data-input_value');
+    const newCaretPosition = parseInt(this.el.getAttribute('data-caret_position'));
+
     if (newValue !== '') {
       this.el.value = newValue;
+      this.el.setSelectionRange(newCaretPosition, newCaretPosition);
     }
   }
 }

--- a/lib/elixir_console/autocomplete.ex
+++ b/lib/elixir_console/autocomplete.ex
@@ -48,12 +48,12 @@ defmodule ElixirConsole.Autocomplete do
   word) and the new caret position (right after the last character of the
   autocompleted word)
   """
-  def autocompleted_input(value, caret_position, suggestion) do
+  def autocompleted_input(value, caret_position, autocompleted_word) do
     word_to_autocomplete = word_to_autocomplete(value, caret_position)
 
     {
-      calculate_new_input_value(value, caret_position, word_to_autocomplete, suggestion),
-      calculate_new_caret_position(caret_position, word_to_autocomplete, suggestion)
+      calculate_new_input_value(value, caret_position, word_to_autocomplete, autocompleted_word),
+      calculate_new_caret_position(caret_position, word_to_autocomplete, autocompleted_word)
     }
   end
 
@@ -67,15 +67,20 @@ defmodule ElixirConsole.Autocomplete do
      String.slice(value, caret_position, @max_command_length)}
   end
 
-  defp calculate_new_caret_position(caret_position, word_to_autocomplete, suggestion) do
-    String.length(suggestion) - String.length(word_to_autocomplete) + caret_position
+  defp calculate_new_caret_position(caret_position, word_to_autocomplete, autocompleted_word) do
+    String.length(autocompleted_word) - String.length(word_to_autocomplete) + caret_position
   end
 
-  defp calculate_new_input_value(input_value, caret_position, word_to_autocomplete, suggestion) do
+  defp calculate_new_input_value(
+         input_value,
+         caret_position,
+         word_to_autocomplete,
+         autocompleted_word
+       ) do
     {value_until_caret, value_from_caret} =
       split_command_for_autocomplete(input_value, caret_position)
 
-    Regex.replace(~r/\.*#{word_to_autocomplete}$/, value_until_caret, suggestion) <>
+    Regex.replace(~r/\.*#{word_to_autocomplete}$/, value_until_caret, autocompleted_word) <>
       value_from_caret
   end
 end

--- a/lib/elixir_console/autocomplete.ex
+++ b/lib/elixir_console/autocomplete.ex
@@ -24,16 +24,21 @@ defmodule ElixirConsole.Autocomplete do
   end
 
   @doc """
-  Returns a modified version of the command input value with an autocompleted word.
-  It means that the `suggestion` value is used to replace the word that ends in the
-  `caret_position` position of the provided `value`
+  Returns a modified version of the command input value with an autocompleted
+  word. It means that the `suggestion` value is used to replace the word that
+  ends in the `caret_position` position of the provided `value`.
+
+  It returns a tuple with the new input command (modified with the autocompleted
+  word) and the new caret position (right after the last character of the
+  autocompleted word)
   """
   def autocompleted_input(value, caret_position, suggestion) do
     word_to_autocomplete = word_to_autocomplete(value, caret_position)
-    {value_until_caret, value_from_caret} = split_command_for_autocomplete(value, caret_position)
 
-    Regex.replace(~r/\.*#{word_to_autocomplete}$/, value_until_caret, suggestion) <>
-      value_from_caret
+    {
+      calculate_new_input_value(value, caret_position, word_to_autocomplete, suggestion),
+      calculate_new_caret_position(caret_position, word_to_autocomplete, suggestion)
+    }
   end
 
   defp word_to_autocomplete(value, caret_position) do
@@ -44,5 +49,15 @@ defmodule ElixirConsole.Autocomplete do
   defp split_command_for_autocomplete(value, caret_position) do
     {String.slice(value, 0, caret_position),
      String.slice(value, caret_position, @max_command_length)}
+  end
+
+  defp calculate_new_caret_position(caret_position, word_to_autocomplete, suggestion) do
+    String.length(suggestion) - String.length(word_to_autocomplete) + caret_position
+  end
+
+  defp calculate_new_input_value(input_value, caret_position, word_to_autocomplete, suggestion) do
+    {value_until_caret, value_from_caret} = split_command_for_autocomplete(input_value, caret_position)
+    Regex.replace(~r/\.*#{word_to_autocomplete}$/, value_until_caret, suggestion) <>
+      value_from_caret
   end
 end

--- a/lib/elixir_console_web/live/console_live.ex
+++ b/lib/elixir_console_web/live/console_live.ex
@@ -35,6 +35,7 @@ defmodule ElixirConsoleWeb.ConsoleLive do
               phx-keydown="suggest"
               phx-hook="CommandInput"
               data-input_value="<%= @input_value %>"
+              data-caret_position="<%= @caret_position %>"
             />
           </div>
         </form>
@@ -102,10 +103,14 @@ defmodule ElixirConsoleWeb.ConsoleLive do
 
     case Autocomplete.get_suggestions(value, caret_position, bindings) do
       [suggestion] ->
+        {new_input, new_caret_position} =
+          Autocomplete.autocompleted_input(value, caret_position, suggestion)
+
         {:noreply,
          assign(socket,
            suggestions: [],
-           input_value: Autocomplete.autocompleted_input(value, caret_position, suggestion)
+           input_value: new_input,
+           caret_position: new_caret_position
          )}
 
       suggestions ->

--- a/test/elixir_console/autocomplete_test.exs
+++ b/test/elixir_console/autocomplete_test.exs
@@ -1,5 +1,5 @@
 defmodule ElixirConsole.AutocompleteTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias ElixirConsole.Autocomplete
 
   describe "get_suggestions" do
@@ -43,6 +43,22 @@ defmodule ElixirConsole.AutocompleteTest do
                "List.foldr",
                "List.improper?"
              ]
+    end
+  end
+
+  describe "autocompleted_input" do
+    test "returns updated input value and caret position" do
+      assert Autocomplete.autocompleted_input("3 + Enum.cou", 12, "Enum.count") == {
+               "3 + Enum.count",
+               14
+             }
+    end
+
+    test "returns modifications when it happens in the middle of the input string" do
+      assert Autocomplete.autocompleted_input("Enum.cou([1]) + 3", 8, "Enum.count") == {
+               "Enum.count([1]) + 3",
+               10
+             }
     end
   end
 end

--- a/test/elixir_console/autocomplete_test.exs
+++ b/test/elixir_console/autocomplete_test.exs
@@ -1,0 +1,48 @@
+defmodule ElixirConsole.AutocompleteTest do
+  use ExUnit.Case
+  alias ElixirConsole.Autocomplete
+
+  describe "get_suggestions" do
+    test "returns no suggestions" do
+      assert Autocomplete.get_suggestions("Foo.bar", 8, []) == []
+    end
+
+    test "returns no suggestions when the caret is in the middle" do
+      assert Autocomplete.get_suggestions("Foo.bar", 4, []) == []
+    end
+
+    test "returns suggestions with the caret" do
+      assert Autocomplete.get_suggestions("Enum.co", 7, []) == ["Enum.concat", "Enum.count"]
+    end
+
+    test "returns suggestions with the caret is in the middle" do
+      assert Autocomplete.get_suggestions("Enum.ch foo bar", 7, []) == [
+               "Enum.chunk_by",
+               "Enum.chunk_every",
+               "Enum.chunk_while"
+             ]
+    end
+
+    test "returns suggestions from bindings" do
+      assert Autocomplete.get_suggestions("4 + va", 6, var1: 1, var2: 2) == [
+               "var1",
+               "var2"
+             ]
+    end
+
+    test "returns suggestions including bindings and Elixir functions" do
+      assert Autocomplete.get_suggestions("List", 4, Listado: 1) == [
+               "Listado",
+               "List.ascii_printable?",
+               "List.delete",
+               "List.delete_at",
+               "List.duplicate",
+               "List.first",
+               "List.flatten",
+               "List.foldl",
+               "List.foldr",
+               "List.improper?"
+             ]
+    end
+  end
+end

--- a/test/elixir_console/autocomplete_test.exs
+++ b/test/elixir_console/autocomplete_test.exs
@@ -11,11 +11,11 @@ defmodule ElixirConsole.AutocompleteTest do
       assert Autocomplete.get_suggestions("Foo.bar", 4, []) == []
     end
 
-    test "returns suggestions with the caret" do
+    test "returns suggestions" do
       assert Autocomplete.get_suggestions("Enum.co", 7, []) == ["Enum.concat", "Enum.count"]
     end
 
-    test "returns suggestions with the caret is in the middle" do
+    test "returns suggestions when the caret is in the middle" do
       assert Autocomplete.get_suggestions("Enum.ch foo bar", 7, []) == [
                "Enum.chunk_by",
                "Enum.chunk_every",

--- a/test/elixir_console/sandbox/command_validator_test.exs
+++ b/test/elixir_console/sandbox/command_validator_test.exs
@@ -1,5 +1,5 @@
 defmodule ElixirConsole.Sandbox.CommandValidatorTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias ElixirConsole.Sandbox.CommandValidator
 
   describe "safe_command?/1" do

--- a/test/elixir_console/sandbox_test.exs
+++ b/test/elixir_console/sandbox_test.exs
@@ -1,5 +1,5 @@
 defmodule ElixirConsole.SandboxTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias ElixirConsole.Sandbox
 
   setup do

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -1,5 +1,5 @@
 defmodule ElixirConsoleWeb.ConsoleLiveTest do
-  use ElixirConsoleWeb.ConnCase
+  use ElixirConsoleWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
   # Code based on https://github.com/phoenixframework/phoenix_live_view/blob/bba042ed6a6efa45f56b30c4d26fda7a0bdb8991/lib/phoenix_live_view/test/live_view_test.ex#L459

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -113,6 +113,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
         render_keydown(view, "suggest", %{"keyCode" => 9, "value" => "Enum.conc([1,2], [3])"})
 
       assert html =~ ~r/\<input .* data-input_value\="Enum.concat\(\[1,2\], \[3\]\)"/
+      assert html =~ ~r/\<input .* data-caret_position\="11"/
 
       refute html =~ ~r/Suggestions\:.*Enum\.concat/
       assert html =~ "INSTRUCTIONS"


### PR DESCRIPTION
This is a draft PR until #36 is reviewed and merged.

Here we complete the cursor position feature of our autocomplete. It adds the ability of change the cursor position to the most natural place, right after the last character of the autocompleted word.