### PR TITLE
Autocomplete only module name

### DIFF
--- a/lib/elixir_console/autocomplete.ex
+++ b/lib/elixir_console/autocomplete.ex
@@ -20,8 +20,8 @@ defmodule ElixirConsole.Autocomplete do
     |> filter_suggestions(word_to_autocomplete)
   end
 
-  defp all_suggestions_candidates(bindings, modules_or_functions_from_docs) do
-    bindings_variable_names(bindings) ++ elixir_library_names(modules_or_functions_from_docs)
+  defp all_suggestions_candidates(bindings, modules_or_functions) do
+    bindings_variable_names(bindings) ++ elixir_library_names(modules_or_functions)
   end
 
   defp bindings_variable_names(bindings) do

--- a/lib/elixir_console/autocomplete.ex
+++ b/lib/elixir_console/autocomplete.ex
@@ -13,14 +13,15 @@ defmodule ElixirConsole.Autocomplete do
   """
   def get_suggestions(value, caret_position, bindings) do
     word_to_autocomplete = word_to_autocomplete(value, caret_position)
+    modules_or_functions = modules_or_functions_from_docs(word_to_autocomplete)
 
     bindings
-    |> all_suggestions_candidates()
+    |> all_suggestions_candidates(modules_or_functions)
     |> filter_suggestions(word_to_autocomplete)
   end
 
-  defp all_suggestions_candidates(bindings) do
-    bindings_variable_names(bindings) ++ elixir_library_names()
+  defp all_suggestions_candidates(bindings, modules_or_functions_from_docs) do
+    bindings_variable_names(bindings) ++ elixir_library_names(modules_or_functions_from_docs)
   end
 
   defp bindings_variable_names(bindings) do
@@ -29,9 +30,22 @@ defmodule ElixirConsole.Autocomplete do
     |> Enum.sort()
   end
 
-  defp elixir_library_names do
-    Enum.sort(Documentation.get_functions_names())
+  defp modules_or_functions_from_docs(word_to_autocomplete) do
+    if String.match?(word_to_autocomplete, ~r/^[A-Z]\w*\.\w*$/) do
+      :functions
+    else
+      :modules
+    end
   end
+
+  defp elixir_library_names(modules_or_functions) do
+    modules_or_functions
+    |> retrieve_names_from_documentation()
+    |> Enum.sort()
+  end
+
+  defp retrieve_names_from_documentation(:functions), do: Documentation.get_functions_names()
+  defp retrieve_names_from_documentation(:modules), do: Documentation.get_modules_names()
 
   defp filter_suggestions(candidates, word_to_autocomplete) do
     candidates

--- a/lib/elixir_console/documentation.ex
+++ b/lib/elixir_console/documentation.ex
@@ -63,9 +63,21 @@ defmodule ElixirConsole.Documentation do
     {:reply, functions_names, docs}
   end
 
+  @impl true
+  def handle_call(:get_modules_names, _from, docs) do
+    modules_names =
+      Map.values(docs)
+      |> Enum.map(& &1.module_name)
+      |> Enum.uniq()
+
+    {:reply, modules_names, docs}
+  end
+
   def get_doc(key), do: GenServer.call(__MODULE__, {:get, key})
 
   def get_functions_names(), do: GenServer.call(__MODULE__, :get_functions_names)
+
+  def get_modules_names(), do: GenServer.call(__MODULE__, :get_modules_names)
 
   defp retrieve_docs([module | remaining_modules]) do
     {:docs_v1, _, :elixir, _, _, _, list} = Code.fetch_docs(module)
@@ -79,6 +91,7 @@ defmodule ElixirConsole.Documentation do
 
             Map.put(acc, %Key{func_name: "#{module_name}.#{func_name}", arity: func_ary}, %{
               func_name: "#{module_name}.#{func_name}/#{func_ary}",
+              module_name: module_name,
               header: header,
               docs: html_doc,
               link: "https://hexdocs.pm/elixir/#{module_name}.html##{func_name}/#{func_ary}"

--- a/test/elixir_console/autocomplete_test.exs
+++ b/test/elixir_console/autocomplete_test.exs
@@ -27,8 +27,6 @@ defmodule ElixirConsole.AutocompleteTest do
       assert Autocomplete.get_suggestions("Li", 3, []) == ["List"]
     end
 
-    # TODO think if we should return [] in this case, it is a useless replacement
-    # (but maybe this is fine in the sake of easier code)
     test "returns only the module name if this is the last word" do
       assert Autocomplete.get_suggestions("12 + Enum", 9, []) == ["Enum", "Enumerable"]
     end

--- a/test/elixir_console/autocomplete_test.exs
+++ b/test/elixir_console/autocomplete_test.exs
@@ -23,16 +23,18 @@ defmodule ElixirConsole.AutocompleteTest do
              ]
     end
 
-    test "returns suggestions from bindings" do
-      assert Autocomplete.get_suggestions("4 + va", 6, var1: 1, var2: 2) == [
-               "var1",
-               "var2"
-             ]
+    test "returns suggestions only for the module name" do
+      assert Autocomplete.get_suggestions("Li", 3, []) == ["List"]
     end
 
-    test "returns suggestions including bindings and Elixir functions" do
-      assert Autocomplete.get_suggestions("List", 4, Listado: 1) == [
-               "Listado",
+    # TODO think if we should return [] in this case, it is a useless replacement
+    # (but maybe this is fine in the sake of easier code)
+    test "returns only the module name if this is the last word" do
+      assert Autocomplete.get_suggestions("12 + Enum", 9, []) == ["Enum", "Enumerable"]
+    end
+
+    test "returns functions names when the last word includes module name and period" do
+      assert Autocomplete.get_suggestions("12 + List.", 10, []) == [
                "List.ascii_printable?",
                "List.delete",
                "List.delete_at",
@@ -41,7 +43,15 @@ defmodule ElixirConsole.AutocompleteTest do
                "List.flatten",
                "List.foldl",
                "List.foldr",
-               "List.improper?"
+               "List.improper?",
+               "List.insert_at"
+             ]
+    end
+
+    test "returns suggestions from bindings" do
+      assert Autocomplete.get_suggestions("4 + va", 6, var1: 1, var2: 2) == [
+               "var1",
+               "var2"
              ]
     end
   end


### PR DESCRIPTION
This PR adds the ability to autocomplete the module and function parts independently.

`Enu` will suggest `Emum`, `Enumerable`
`Lis` will autocomplete to `List`

When we have something like `Enum.co`, behavior does not change.. it will suggest `Enum.count` and `Enum.concat`