### PR TITLE
Display docs for kernel functions

### DIFF
--- a/lib/elixir_console/contextual_help.ex
+++ b/lib/elixir_console/contextual_help.ex
@@ -1,6 +1,15 @@
 defmodule ElixirConsole.ContextualHelp do
+  @moduledoc """
+  Utilities to add metadata to an user-generated Elixir command about the
+  standard library functions that are in use.
+  """
+
   alias ElixirConsole.Documentation
 
+  @doc """
+  Takes an Elixir command and returns it divided in parts, and the ones that
+  correspond to Elixir functions are augmented with metadata containing the docs
+  """
   def compute(command) do
     case Code.string_to_quoted(command) do
       {:ok, expr} ->

--- a/lib/elixir_console/documentation.ex
+++ b/lib/elixir_console/documentation.ex
@@ -74,7 +74,8 @@ defmodule ElixirConsole.Documentation do
     docs =
       Enum.reduce(list, %{}, fn function, acc ->
         case function do
-          {{:function, func_name, func_ary}, _, header, %{"en" => docs}, _} ->
+          {{function_or_macro, func_name, func_ary}, _, header, %{"en" => docs}, _}
+          when function_or_macro in [:function, :macro] ->
             {:ok, html_doc, _} = Earmark.as_html(docs)
             [module_name] = Module.split(module)
 

--- a/lib/elixir_console/documentation.ex
+++ b/lib/elixir_console/documentation.ex
@@ -6,6 +6,7 @@ defmodule ElixirConsole.Documentation do
     defstruct [:func_name, :arity]
   end
 
+  @az_range 97..122
   @modules [
     Access,
     Enum,
@@ -80,6 +81,7 @@ defmodule ElixirConsole.Documentation do
             [module_name] = Module.split(module)
 
             Map.put(acc, %Key{func_name: "#{module_name}.#{func_name}", arity: func_ary}, %{
+              type: function_or_operator(func_name),
               func_name: "#{module_name}.#{func_name}/#{func_ary}",
               header: header,
               docs: html_doc,
@@ -106,4 +108,13 @@ defmodule ElixirConsole.Documentation do
       nil -> nil
     end
   end
+
+  defp function_or_operator(func_name) when is_atom(func_name) do
+    func_name
+    |> to_charlist
+    |> function_or_operator
+  end
+
+  defp function_or_operator([first_char | _]) when first_char in @az_range, do: :function
+  defp function_or_operator(_), do: :operator
 end

--- a/lib/elixir_console/documentation.ex
+++ b/lib/elixir_console/documentation.ex
@@ -36,7 +36,8 @@ defmodule ElixirConsole.Documentation do
     Inspect,
     Protocol,
     Code,
-    Macro
+    Macro,
+    Kernel
   ]
 
   def start_link(_) do

--- a/lib/elixir_console_web/live/console_live.ex
+++ b/lib/elixir_console_web/live/console_live.ex
@@ -228,7 +228,7 @@ defmodule ElixirConsoleWeb.ConsoleLive do
   defp print_prompt, do: "> "
 
   defp format_command(command) do
-    for part <- splitted_command(command) do
+    for part <- split_command(command) do
       case part do
         {part, help_metadata} ->
           render_command_inline_help(part, help_metadata)
@@ -239,11 +239,12 @@ defmodule ElixirConsoleWeb.ConsoleLive do
     end
   end
 
-  defp splitted_command(command) do
+  defp split_command(command) do
     ContextualHelp.compute(command)
   end
 
   defp render_command_inline_help(part, %{
+         type: function_or_operator,
          func_name: func_name,
          header: header,
          docs: docs,
@@ -255,7 +256,10 @@ defmodule ElixirConsoleWeb.ConsoleLive do
       phx-value-header="<%= header %>"
       phx-value-doc="<%= docs %>"
       phx-value-link="<%= link %>"
-      class="text-green-400 cursor-pointer underline"
+      class="<%= inline_help_class_for(function_or_operator) %>"
     ><%= part %></span>}
   end
+
+  defp inline_help_class_for(:function), do: "text-green-400 cursor-pointer underline"
+  defp inline_help_class_for(:operator), do: "cursor-pointer"
 end

--- a/test/elixir_console/contextual_help_test.exs
+++ b/test/elixir_console/contextual_help_test.exs
@@ -47,4 +47,18 @@ defmodule ElixirConsole.ContextualHelpTest do
              "([1,2,3])"
            ] = ContextualHelp.compute("length([1,2,3])")
   end
+
+  test "adds documentation metadata to Kernel macros" do
+    assert [
+             "3 ",
+             {"||",
+              %{
+                docs: _,
+                func_name: "Kernel.||/2",
+                header: ["left || right"],
+                link: "https://hexdocs.pm/elixir/Kernel.html#||/2"
+              }},
+             " 4"
+           ] = ContextualHelp.compute("3 || 4")
+  end
 end

--- a/test/elixir_console/contextual_help_test.exs
+++ b/test/elixir_console/contextual_help_test.exs
@@ -1,0 +1,36 @@
+defmodule ElixirConsole.ContextualHelpTest do
+  use ExUnit.Case, async: true
+  alias ElixirConsole.ContextualHelp
+
+  test "returns only one element if no Elixir functions are found" do
+    assert ContextualHelp.compute("foo(1 + 4)") == ["foo(1 + 4)"]
+  end
+
+  test "adds documentation metadata if Elixir function is found" do
+    assert [
+             "",
+             {"Enum.count",
+              %{
+                docs: _,
+                func_name: "Enum.count/1",
+                header: ["count(enumerable)"],
+                link: "https://hexdocs.pm/elixir/Enum.html#count/1"
+              }},
+             "([1,2]) + 3"
+           ] = ContextualHelp.compute("Enum.count([1,2]) + 3")
+  end
+
+  test "adds documentation metadata properly when omitting default parameters" do
+    assert [
+             "",
+             {"Enum.find",
+              %{
+                docs: _,
+                func_name: "Enum.find/3",
+                header: ["find(enumerable, default \\\\ nil, fun)"],
+                link: "https://hexdocs.pm/elixir/Enum.html#find/3"
+              }},
+             "([2, 3, 4], fn x -> x == 2 end)"
+           ] = ContextualHelp.compute("Enum.find([2, 3, 4], fn x -> x == 2 end)")
+  end
+end

--- a/test/elixir_console/contextual_help_test.exs
+++ b/test/elixir_console/contextual_help_test.exs
@@ -3,7 +3,7 @@ defmodule ElixirConsole.ContextualHelpTest do
   alias ElixirConsole.ContextualHelp
 
   test "returns only one element if no Elixir functions are found" do
-    assert ContextualHelp.compute("foo(1 + 4)") == ["foo(1 + 4)"]
+    assert ContextualHelp.compute("foo(1)") == ["foo(1)"]
   end
 
   test "adds documentation metadata if Elixir function is found" do
@@ -16,8 +16,8 @@ defmodule ElixirConsole.ContextualHelpTest do
                 header: ["count(enumerable)"],
                 link: "https://hexdocs.pm/elixir/Enum.html#count/1"
               }},
-             "([1,2]) + 3"
-           ] = ContextualHelp.compute("Enum.count([1,2]) + 3")
+             "([1,2])"
+           ] = ContextualHelp.compute("Enum.count([1,2])")
   end
 
   test "adds documentation metadata properly when omitting default parameters" do
@@ -30,7 +30,21 @@ defmodule ElixirConsole.ContextualHelpTest do
                 header: ["find(enumerable, default \\\\ nil, fun)"],
                 link: "https://hexdocs.pm/elixir/Enum.html#find/3"
               }},
-             "([2, 3, 4], fn x -> x == 2 end)"
-           ] = ContextualHelp.compute("Enum.find([2, 3, 4], fn x -> x == 2 end)")
+             "([2, 3, 4], fn x -> x end)"
+           ] = ContextualHelp.compute("Enum.find([2, 3, 4], fn x -> x end)")
+  end
+
+  test "adds documentation metadata to Kernel functions" do
+    assert [
+             "",
+             {"length",
+              %{
+                docs: _,
+                func_name: "Kernel.length/1",
+                header: ["length(list)"],
+                link: "https://hexdocs.pm/elixir/Kernel.html#length/1"
+              }},
+             "([1,2,3])"
+           ] = ContextualHelp.compute("length([1,2,3])")
   end
 end

--- a/test/elixir_console/contextual_help_test.exs
+++ b/test/elixir_console/contextual_help_test.exs
@@ -11,7 +11,6 @@ defmodule ElixirConsole.ContextualHelpTest do
              "",
              {"Enum.count",
               %{
-                docs: _,
                 func_name: "Enum.count/1",
                 header: ["count(enumerable)"],
                 link: "https://hexdocs.pm/elixir/Enum.html#count/1"
@@ -25,7 +24,6 @@ defmodule ElixirConsole.ContextualHelpTest do
              "",
              {"Enum.find",
               %{
-                docs: _,
                 func_name: "Enum.find/3",
                 header: ["find(enumerable, default \\\\ nil, fun)"],
                 link: "https://hexdocs.pm/elixir/Enum.html#find/3"
@@ -39,7 +37,6 @@ defmodule ElixirConsole.ContextualHelpTest do
              "",
              {"length",
               %{
-                docs: _,
                 func_name: "Kernel.length/1",
                 header: ["length(list)"],
                 link: "https://hexdocs.pm/elixir/Kernel.html#length/1"
@@ -53,12 +50,27 @@ defmodule ElixirConsole.ContextualHelpTest do
              "3 ",
              {"||",
               %{
-                docs: _,
                 func_name: "Kernel.||/2",
                 header: ["left || right"],
                 link: "https://hexdocs.pm/elixir/Kernel.html#||/2"
               }},
              " 4"
            ] = ContextualHelp.compute("3 || 4")
+  end
+
+  test "adds metadata indicating whether is function or operator" do
+    assert [
+             "5 ",
+             {"+",
+              %{
+                type: :operator
+              }},
+             " ",
+             {"Enum.count",
+              %{
+                type: :function
+              }},
+             "([2,4])"
+           ] = ContextualHelp.compute("5 + Enum.count([2,4])")
   end
 end

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -29,7 +29,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
     setup :render_with_valid_command
 
     test "command is visible in the console history", %{html: html} do
-      assert html =~ "&gt; a = 1 + 2"
+      assert html =~ ~r/&gt; a = 1 <span [\S \n]*>\+<\/span> 2/
     end
 
     test "command result is displayed", %{html: html} do


### PR DESCRIPTION
Completes the feature of displaying inline documentation for Elixir functions. Now, it also includes `Kernel` functions and macros.