### PR TITLE
Fix string interpolation commands

### DIFF
--- a/lib/elixir_console/autocomplete.ex
+++ b/lib/elixir_console/autocomplete.ex
@@ -31,10 +31,15 @@ defmodule ElixirConsole.Autocomplete do
   end
 
   defp modules_or_functions_from_docs(word_to_autocomplete) do
-    if String.match?(word_to_autocomplete, ~r/^[A-Z]\w*\.\w*$/) do
-      :functions
-    else
-      :modules
+    cond do
+      String.match?(word_to_autocomplete, ~r/^[A-Z]\w*\.\w*$/) ->
+        :functions
+
+      String.match?(word_to_autocomplete, ~r/^[a-z]/) ->
+        :kernel_functions
+
+      true ->
+        :modules
     end
   end
 
@@ -45,6 +50,10 @@ defmodule ElixirConsole.Autocomplete do
   end
 
   defp retrieve_names_from_documentation(:functions), do: Documentation.get_functions_names()
+
+  defp retrieve_names_from_documentation(:kernel_functions),
+    do: Documentation.get_kernel_functions_names()
+
   defp retrieve_names_from_documentation(:modules), do: Documentation.get_modules_names()
 
   defp filter_suggestions(candidates, word_to_autocomplete) do

--- a/lib/elixir_console/documentation.ex
+++ b/lib/elixir_console/documentation.ex
@@ -66,6 +66,17 @@ defmodule ElixirConsole.Documentation do
   end
 
   @impl true
+  def handle_call(:get_kernel_functions_names, _from, docs) do
+    functions_names =
+      Map.values(docs)
+      |> Enum.filter(&(&1.module_name == "Kernel"))
+      |> Enum.map(& &1.bare_func_name)
+      |> Enum.uniq()
+
+    {:reply, functions_names, docs}
+  end
+
+  @impl true
   def handle_call(:get_modules_names, _from, docs) do
     modules_names =
       Map.values(docs)
@@ -78,7 +89,7 @@ defmodule ElixirConsole.Documentation do
   def get_doc(key), do: GenServer.call(__MODULE__, {:get, key})
 
   def get_functions_names(), do: GenServer.call(__MODULE__, :get_functions_names)
-
+  def get_kernel_functions_names(), do: GenServer.call(__MODULE__, :get_kernel_functions_names)
   def get_modules_names(), do: GenServer.call(__MODULE__, :get_modules_names)
 
   defp retrieve_docs([module | remaining_modules]) do
@@ -95,6 +106,7 @@ defmodule ElixirConsole.Documentation do
             Map.put(acc, %Key{func_name: "#{module_name}.#{func_name}", arity: func_ary}, %{
               type: function_or_operator(func_name),
               func_name: "#{module_name}.#{func_name}/#{func_ary}",
+              bare_func_name: to_string(func_name),
               module_name: module_name,
               header: header,
               docs: html_doc,

--- a/lib/elixir_console/documentation.ex
+++ b/lib/elixir_console/documentation.ex
@@ -57,6 +57,7 @@ defmodule ElixirConsole.Documentation do
     Port,
     StringIO,
     System,
+    String,
     Calendar,
     Agent,
     Application,

--- a/lib/elixir_console/documentation.ex
+++ b/lib/elixir_console/documentation.ex
@@ -3,10 +3,45 @@ defmodule ElixirConsole.Documentation do
 
   defmodule Key do
     @enforce_keys [:func_name, :arity]
-    defstruct [:func_name, :arity]
+    defstruct @enforce_keys
   end
 
-  @az_range 97..122
+  defmodule DocEntry do
+    @enforce_keys [:module_name, :func_name, :func_ary, :docs_header, :docs_body]
+    defstruct @enforce_keys
+
+    @az_range 97..122
+
+    def build_docs_metadata(nil), do: nil
+
+    def build_docs_metadata(doc_entry) do
+      %DocEntry{
+        module_name: module_name,
+        func_name: func_name,
+        func_ary: func_ary,
+        docs_header: docs_header,
+        docs_body: docs_body
+      } = doc_entry
+
+      %{
+        type: function_or_operator(func_name),
+        func_name: "#{module_name}.#{func_name}/#{func_ary}",
+        header: docs_header,
+        docs: docs_body,
+        link: "https://hexdocs.pm/elixir/#{module_name}.html##{func_name}/#{func_ary}"
+      }
+    end
+
+    defp function_or_operator(func_name) when is_atom(func_name) do
+      func_name
+      |> to_charlist
+      |> function_or_operator
+    end
+
+    defp function_or_operator([first_char | _]) when first_char in @az_range, do: :function
+    defp function_or_operator(_), do: :operator
+  end
+
   @modules [
     Access,
     Enum,
@@ -52,7 +87,8 @@ defmodule ElixirConsole.Documentation do
 
   @impl true
   def handle_call({:get, key}, _from, docs) do
-    {:reply, docs[key] || find_with_greater_arity(key, docs), docs}
+    doc = docs[key] || find_with_greater_arity(key, docs)
+    {:reply, DocEntry.build_docs_metadata(doc), docs}
   end
 
   @impl true
@@ -70,7 +106,7 @@ defmodule ElixirConsole.Documentation do
     functions_names =
       Map.values(docs)
       |> Enum.filter(&(&1.module_name == "Kernel"))
-      |> Enum.map(& &1.bare_func_name)
+      |> Enum.map(&to_string(&1.func_name))
       |> Enum.uniq()
 
     {:reply, functions_names, docs}
@@ -92,6 +128,8 @@ defmodule ElixirConsole.Documentation do
   def get_kernel_functions_names(), do: GenServer.call(__MODULE__, :get_kernel_functions_names)
   def get_modules_names(), do: GenServer.call(__MODULE__, :get_modules_names)
 
+  defp retrieve_docs([]), do: %{}
+
   defp retrieve_docs([module | remaining_modules]) do
     {:docs_v1, _, :elixir, _, _, _, list} = Code.fetch_docs(module)
 
@@ -103,15 +141,17 @@ defmodule ElixirConsole.Documentation do
             {:ok, html_doc, _} = Earmark.as_html(docs)
             [module_name] = Module.split(module)
 
-            Map.put(acc, %Key{func_name: "#{module_name}.#{func_name}", arity: func_ary}, %{
-              type: function_or_operator(func_name),
-              func_name: "#{module_name}.#{func_name}/#{func_ary}",
-              bare_func_name: to_string(func_name),
-              module_name: module_name,
-              header: header,
-              docs: html_doc,
-              link: "https://hexdocs.pm/elixir/#{module_name}.html##{func_name}/#{func_ary}"
-            })
+            Map.put(
+              acc,
+              %Key{func_name: "#{module_name}.#{func_name}", arity: func_ary},
+              %DocEntry{
+                module_name: module_name,
+                func_name: func_name,
+                func_ary: func_ary,
+                docs_header: header,
+                docs_body: html_doc
+              }
+            )
 
           _ ->
             acc
@@ -120,8 +160,6 @@ defmodule ElixirConsole.Documentation do
 
     Map.merge(docs, retrieve_docs(remaining_modules))
   end
-
-  defp retrieve_docs([]), do: %{}
 
   defp find_with_greater_arity(%Key{func_name: func_name, arity: func_ary}, docs) do
     with {_, doc} <-
@@ -133,13 +171,4 @@ defmodule ElixirConsole.Documentation do
       nil -> nil
     end
   end
-
-  defp function_or_operator(func_name) when is_atom(func_name) do
-    func_name
-    |> to_charlist
-    |> function_or_operator
-  end
-
-  defp function_or_operator([first_char | _]) when first_char in @az_range, do: :function
-  defp function_or_operator(_), do: :operator
 end

--- a/lib/elixir_console/sandbox/erlang_modules_absence.ex
+++ b/lib/elixir_console/sandbox/erlang_modules_absence.ex
@@ -6,6 +6,8 @@ defmodule ElixirConsole.Sandbox.ErlangModulesAbsence do
   alias ElixirConsole.Sandbox.CommandValidator
   @behaviour CommandValidator
 
+  @az_range 97..122
+
   @impl CommandValidator
   def validate(ast) do
     {_ast, result} = Macro.prewalk(ast, [], &valid?(&1, &2))
@@ -25,9 +27,24 @@ defmodule ElixirConsole.Sandbox.ErlangModulesAbsence do
     end
   end
 
-  defp valid?({:., _, [erlang_module, _]} = elem, acc) when is_atom(erlang_module) do
-    {elem, [{:error, erlang_module} | acc]}
+  defp valid?({:., _, [module, _]} = elem, acc) do
+    if is_erlang_module?(module) do
+      {elem, [{:error, module} | acc]}
+    else
+      {elem, acc}
+    end
   end
 
   defp valid?(elem, acc), do: {elem, acc}
+
+  defp is_erlang_module?(module) when not is_atom(module), do: false
+
+  defp is_erlang_module?(module) do
+    module
+    |> to_charlist
+    |> starts_with_lowercase?
+  end
+
+  defp starts_with_lowercase?([first_char | _]) when first_char in @az_range, do: true
+  defp starts_with_lowercase?(_module_charlist), do: false
 end

--- a/test/elixir_console/autocomplete_test.exs
+++ b/test/elixir_console/autocomplete_test.exs
@@ -47,10 +47,14 @@ defmodule ElixirConsole.AutocompleteTest do
     end
 
     test "returns suggestions from bindings" do
-      assert Autocomplete.get_suggestions("4 + va", 6, var1: 1, var2: 2) == [
-               "var1",
-               "var2"
+      assert Autocomplete.get_suggestions("4 + varia", 9, variable1: 1, variable2: 2) == [
+               "variable1",
+               "variable2"
              ]
+    end
+
+    test "returns suggestions from Kernel functions" do
+      assert Autocomplete.get_suggestions("4 + le", 6, []) == ["length"]
     end
   end
 

--- a/test/elixir_console/sandbox/command_validator_test.exs
+++ b/test/elixir_console/sandbox/command_validator_test.exs
@@ -31,6 +31,10 @@ defmodule ElixirConsole.Sandbox.CommandValidatorTest do
       assert :ok == CommandValidator.safe_command?("Kernel.length([])")
     end
 
+    test "returns :ok when using string interpolation" do
+      assert :ok == CommandValidator.safe_command?("\"foo \#{10} bar\"")
+    end
+
     test "returns :error when using an invalid Kernel function" do
       assert {:error,
               "It is allowed to invoke only safe Kernel functions. " <>


### PR DESCRIPTION
Commands like `a = "foo #{33} bar"` were resulting in an error message.

Also, in this PR we add a missing module to the documentation caché module.