### PR TITLE
Do not autocomplete unsafe Elixir code

### DIFF
--- a/lib/elixir_console/elixir_safe_parts.ex
+++ b/lib/elixir_console/elixir_safe_parts.ex
@@ -149,6 +149,8 @@ defmodule ElixirConsole.ElixirSafeParts do
 
   def safe_modules, do: @safe_modules
 
+  def safe_elixir_modules, do: Enum.map(@safe_modules, &:"Elixir.#{&1}")
+
   def unsafe_kernel_functions do
     all_kernel_functions() -- @safe_kernel_functions
   end

--- a/test/elixir_console/autocomplete_test.exs
+++ b/test/elixir_console/autocomplete_test.exs
@@ -56,6 +56,14 @@ defmodule ElixirConsole.AutocompleteTest do
     test "returns suggestions from Kernel functions" do
       assert Autocomplete.get_suggestions("4 + le", 6, []) == ["length"]
     end
+
+    test "does not return unsafe functions into the suggestions" do
+      assert Autocomplete.get_suggestions("spawn", 5, []) == []
+    end
+
+    test "does not return unsafe modules into the suggestions" do
+      assert Autocomplete.get_suggestions("Cod", 3, []) == []
+    end
   end
 
   describe "autocompleted_input" do


### PR DESCRIPTION
The idea is to prevent autocomplete Elixir modules or functions that are not allowed to be executed. Also, this changes prevent to display links to Elixir docs for code that is displayed in the console history but it was not safe enough to be run (so the user experience is consistent)