### PR TITLE
Fix problem with inline docs in nested expressions

### DIFF
--- a/lib/elixir_console/contextual_help.ex
+++ b/lib/elixir_console/contextual_help.ex
@@ -118,6 +118,10 @@ defmodule ElixirConsole.ContextualHelp do
     end
   end
 
+  defp find_functions(list, acc) when is_list(list) do
+    Enum.reduce(list, acc, fn node, acc -> find_functions(node, acc) end)
+  end
+
   defp find_functions({{:., _, [{_, _, [module]}, func_name]}, _, params}, acc) do
     acc = acc ++ [%{module: module, func_name: func_name, func_ary: Enum.count(params)}]
     Enum.reduce(params, acc, fn node, acc -> find_functions(node, acc) end)
@@ -131,6 +135,10 @@ defmodule ElixirConsole.ContextualHelp do
 
   defp find_functions({_, _, list}, acc) when is_list(list) do
     Enum.reduce(list, acc, fn node, acc -> find_functions(node, acc) end)
+  end
+
+  defp find_functions({node_left, node_right}, acc) do
+    find_functions(node_right, find_functions(node_left, acc))
   end
 
   defp find_functions(_, acc), do: acc

--- a/test/elixir_console/contextual_help_test.exs
+++ b/test/elixir_console/contextual_help_test.exs
@@ -19,6 +19,45 @@ defmodule ElixirConsole.ContextualHelpTest do
            ] = ContextualHelp.compute("Enum.count([1,2])")
   end
 
+  test "adds documentation metadata when expression is a list" do
+    assert [
+             "[",
+             {"Enum.count",
+              %{
+                func_name: "Enum.count/1",
+                header: ["count(enumerable)"],
+                link: "https://hexdocs.pm/elixir/Enum.html#count/1"
+              }},
+             "([1,2])]"
+           ] = ContextualHelp.compute("[Enum.count([1,2])]")
+  end
+
+  test "adds documentation metadata when expression is a map" do
+    assert [
+             "%{\"a\" => ",
+             {"Enum.count",
+              %{
+                func_name: "Enum.count/1",
+                header: ["count(enumerable)"],
+                link: "https://hexdocs.pm/elixir/Enum.html#count/1"
+              }},
+             "([1,2])}"
+           ] = ContextualHelp.compute("%{\"a\" => Enum.count([1,2])}")
+  end
+
+  test "adds documentation metadata when expression is a keyword list" do
+    assert [
+             "[a: ",
+             {"Enum.count",
+              %{
+                func_name: "Enum.count/1",
+                header: ["count(enumerable)"],
+                link: "https://hexdocs.pm/elixir/Enum.html#count/1"
+              }},
+             "([1,2])]"
+           ] = ContextualHelp.compute("[a: Enum.count([1,2])]")
+  end
+
   test "adds documentation metadata properly when omitting default parameters" do
     assert [
              "",


### PR DESCRIPTION
This commit fixes issues with the following expressions:

`[hd([45]) | 3]`
`[Enum.count([2,4])]`
`%{a: Enum.count([2,4])}`
`[a: Enum.count([2,4])]`