### PR TITLE
Fix autocomplete caret position issues attempt

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -30,7 +30,7 @@ Hooks.CommandInput = {
       }
     };
 
-    ['keyup', 'click', 'focus'].forEach(event => {
+    ['keydown', 'click', 'focus'].forEach(event => {
       input.addEventListener(event, sendCursorPosition, true);
     });
   },


### PR DESCRIPTION
In production environments we noticed that `suggest` and `position_caret` messages to the LV server are being sent in an unexpected order. This is an attempt to ensure that caret position message goes first and then the `suggest` message.