### PR TITLE
More fixes

### DIFF
--- a/lib/elixir_console/contextual_help.ex
+++ b/lib/elixir_console/contextual_help.ex
@@ -121,8 +121,14 @@ defmodule ElixirConsole.ContextualHelp do
     Enum.reduce(list, acc, fn node, acc -> find_functions(node, acc) end)
   end
 
-  defp find_functions({{:., _, [{_, _, [module]}, func_name]}, _, params}, acc) do
+  defp find_functions({{:., _, [{_, _, [module]}, func_name]}, _, params}, acc)
+       when is_atom(module) do
     acc = acc ++ [%{module: module, func_name: func_name, func_ary: Enum.count(params)}]
+    Enum.reduce(params, acc, fn node, acc -> find_functions(node, acc) end)
+  end
+
+  defp find_functions({{:., _, nested_expression}, _, params}, acc) do
+    acc = find_functions(nested_expression, acc)
     Enum.reduce(params, acc, fn node, acc -> find_functions(node, acc) end)
   end
 

--- a/lib/elixir_console/contextual_help.ex
+++ b/lib/elixir_console/contextual_help.ex
@@ -81,18 +81,6 @@ defmodule ElixirConsole.ContextualHelp do
     put_in
     raise
     reraise
-    sigil_C
-    sigil_D
-    sigil_N
-    sigil_R
-    sigil_S
-    sigil_T
-    sigil_U
-    sigil_W
-    sigil_c
-    sigil_r
-    sigil_s
-    sigil_w
     struct
     struct!
     throw

--- a/test/elixir_console/contextual_help_test.exs
+++ b/test/elixir_console/contextual_help_test.exs
@@ -140,4 +140,10 @@ defmodule ElixirConsole.ContextualHelpTest do
              "(foo).bar"
            ] = ContextualHelp.compute("Map.new(foo).bar")
   end
+
+  @tag :pending
+  test "adds metadata to sigils" do
+    assert ["regex = ", {"Kerne.sigil_r", _}, "/foo|bar/"] =
+             ContextualHelp.compute("regex = ~r/foo|bar/")
+  end
 end

--- a/test/elixir_console/contextual_help_test.exs
+++ b/test/elixir_console/contextual_help_test.exs
@@ -128,4 +128,16 @@ defmodule ElixirConsole.ContextualHelpTest do
              " 5"
            ] = ContextualHelp.compute("Enum.count([2]) + 5")
   end
+
+  test "adds metadata when expression uses dot notation" do
+    assert [
+             "",
+             {"Map.new",
+              %{
+                func_name: "Map.new/1",
+                header: ["new(enumerable)"]
+              }},
+             "(foo).bar"
+           ] = ContextualHelp.compute("Map.new(foo).bar")
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(exclude: [:pending])


### PR DESCRIPTION
Two issues addressed. The cases that are fixed or alleviated are:

`~s(this is a string with "double" quotes, not 'single' ones)`
`Enum.find -50..50, &(rem(&1, 13) == 0)`
`File.stat!(foo).size`