### PR TITLE
Monitor sandbox processes and terminate them when user is gone

### DIFF
--- a/lib/elixir_console/application.ex
+++ b/lib/elixir_console/application.ex
@@ -9,6 +9,7 @@ defmodule ElixirConsole.Application do
     # List all child processes to be supervised
     children = [
       ElixirConsoleWeb.Endpoint,
+      ElixirConsoleWeb.LiveMonitor,
       ElixirConsole.Documentation
     ]
 

--- a/lib/elixir_console/documentation.ex
+++ b/lib/elixir_console/documentation.ex
@@ -1,4 +1,9 @@
 defmodule ElixirConsole.Documentation do
+  @moduledoc """
+  GenServer that holds Elixir functions/macros documentation in memory for fast
+  access.
+  """
+
   use GenServer
 
   defmodule Key do

--- a/lib/elixir_console/sandbox.ex
+++ b/lib/elixir_console/sandbox.ex
@@ -117,8 +117,16 @@ defmodule ElixirConsole.Sandbox do
     end
   end
 
+  @doc """
+  The sandbox process is exited. This function should be used when the sandbox
+  is not longer needed so resources are properly disposed.
+  """
+  def terminate(%__MODULE__{pid: pid}) do
+    Process.exit(pid, :kill)
+  end
+
   defp restore(sandbox) do
-    %{sandbox | pid: init().pid}
+    %__MODULE__{sandbox | pid: init().pid}
   end
 
   defp check_execution_status(pid, [{:ticks, 0} | _]) do

--- a/lib/elixir_console_web/live/live_monitor.ex
+++ b/lib/elixir_console_web/live/live_monitor.ex
@@ -1,0 +1,41 @@
+defmodule ElixirConsoleWeb.LiveMonitor do
+  @moduledoc """
+  This module monitors the created sandbox processes. Gives a way to dispose
+  those processes when they are not longer used.
+
+  The code is based on https://github.com/phoenixframework/phoenix_live_view/issues/123
+  """
+
+  use GenServer
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  def monitor(pid, view_module, meta) do
+    GenServer.call(__MODULE__, {:monitor, pid, view_module, meta})
+  end
+
+  def update_sandbox(pid, view_module, meta) do
+    GenServer.call(__MODULE__, {:update_sandbox, pid, view_module, meta})
+  end
+
+  def init(_) do
+    {:ok, %{views: %{}}}
+  end
+
+  def handle_call({:monitor, pid, view_module, meta}, _from, %{views: views} = state) do
+    Process.monitor(pid)
+    {:reply, :ok, %{state | views: Map.put(views, pid, {view_module, meta})}}
+  end
+
+  def handle_call({:update_sandbox, pid, view_module, meta}, _from, %{views: views} = state) do
+    {:reply, :ok, %{state | views: Map.put(views, pid, {view_module, meta})}}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {{module, meta}, new_views} = Map.pop(state.views, pid)
+    module.unmount(meta)
+    {:noreply, %{state | views: new_views}}
+  end
+end


### PR DESCRIPTION
This is an important PR since sandbox processes need to be terminated when connections are gone. Otherwise, we will be leaking resources.