### PR TITLE
Add mechanism to validate functions invocations at runtime

### DIFF
--- a/lib/elixir_console/sandbox.ex
+++ b/lib/elixir_console/sandbox.ex
@@ -6,7 +6,7 @@ defmodule ElixirConsole.Sandbox do
   @type sandbox() :: %__MODULE__{}
 
   require Logger
-  alias ElixirConsole.Sandbox.CommandValidator
+  alias ElixirConsole.Sandbox.{CommandValidator, RuntimeValidations}
 
   @max_command_length 500
   @max_memory_kb_default 256
@@ -160,7 +160,8 @@ defmodule ElixirConsole.Sandbox do
   defp execute_code(command, bindings) do
     try do
       with :ok <- CommandValidator.safe_command?(command),
-           {result, bindings} <- Code.eval_string(command, bindings) do
+           command_ast <- RuntimeValidations.get_augmented_ast(command),
+           {result, bindings} <- Code.eval_quoted(command_ast, bindings) do
         {:success, {result, bindings}}
       else
         error -> error

--- a/lib/elixir_console/sandbox.ex
+++ b/lib/elixir_console/sandbox.ex
@@ -8,6 +8,11 @@ defmodule ElixirConsole.Sandbox do
   require Logger
   alias ElixirConsole.Sandbox.{CommandValidator, RuntimeValidations}
 
+  # This is just to make available Bitwise macros when evaluating user code
+  # Bitwise is special because the module must be `used` to have access to their
+  # macros
+  use Bitwise
+
   @max_command_length 500
   @max_memory_kb_default 256
   @timeout_ms_default 5000
@@ -161,7 +166,7 @@ defmodule ElixirConsole.Sandbox do
     try do
       with :ok <- CommandValidator.safe_command?(command),
            command_ast <- RuntimeValidations.get_augmented_ast(command),
-           {result, bindings} <- Code.eval_quoted(command_ast, bindings) do
+           {result, bindings} <- Code.eval_quoted(command_ast, bindings, __ENV__) do
         {:success, {result, bindings}}
       else
         error -> error

--- a/lib/elixir_console/sandbox/erlang_modules_absence.ex
+++ b/lib/elixir_console/sandbox/erlang_modules_absence.ex
@@ -3,10 +3,8 @@ defmodule ElixirConsole.Sandbox.ErlangModulesAbsence do
   Analyze the AST and check if Erlang modules are not present.
   """
 
-  alias ElixirConsole.Sandbox.CommandValidator
+  alias ElixirConsole.Sandbox.{CommandValidator, Util}
   @behaviour CommandValidator
-
-  @az_range 97..122
 
   @impl CommandValidator
   def validate(ast) do
@@ -28,7 +26,7 @@ defmodule ElixirConsole.Sandbox.ErlangModulesAbsence do
   end
 
   defp valid?({:., _, [module, _]} = elem, acc) do
-    if is_erlang_module?(module) do
+    if Util.is_erlang_module?(module) do
       {elem, [{:error, module} | acc]}
     else
       {elem, acc}
@@ -36,15 +34,4 @@ defmodule ElixirConsole.Sandbox.ErlangModulesAbsence do
   end
 
   defp valid?(elem, acc), do: {elem, acc}
-
-  defp is_erlang_module?(module) when not is_atom(module), do: false
-
-  defp is_erlang_module?(module) do
-    module
-    |> to_charlist
-    |> starts_with_lowercase?
-  end
-
-  defp starts_with_lowercase?([first_char | _]) when first_char in @az_range, do: true
-  defp starts_with_lowercase?(_module_charlist), do: false
 end

--- a/lib/elixir_console/sandbox/runtime_validations.ex
+++ b/lib/elixir_console/sandbox/runtime_validations.ex
@@ -4,7 +4,7 @@ defmodule ElixirConsole.Sandbox.RuntimeValidations do
     ensures that non-secure functions are not invoked at runtime.
   """
 
-  @this_module Module.split(__MODULE__) |> Enum.map(&String.to_atom/1)
+  @this_module __MODULE__ |> Module.split() |> Enum.map(&String.to_atom/1)
   @valid_modules ElixirConsole.ElixirSafeParts.safe_elixir_modules()
   @kernel_functions_blacklist ElixirConsole.ElixirSafeParts.unsafe_kernel_functions()
 

--- a/lib/elixir_console/sandbox/runtime_validations.ex
+++ b/lib/elixir_console/sandbox/runtime_validations.ex
@@ -4,8 +4,6 @@ defmodule ElixirConsole.Sandbox.RuntimeValidations do
     ensures that non-secure functions are not invoked at runtime.
   """
 
-  alias ElixirConsole.Sandbox.Util
-
   @this_module __MODULE__ |> Module.split() |> Enum.map(&String.to_atom/1)
   @valid_modules ElixirConsole.ElixirSafeParts.safe_elixir_modules()
   @kernel_functions_blacklist ElixirConsole.ElixirSafeParts.unsafe_kernel_functions()

--- a/lib/elixir_console/sandbox/runtime_validations.ex
+++ b/lib/elixir_console/sandbox/runtime_validations.ex
@@ -15,9 +15,26 @@ defmodule ElixirConsole.Sandbox.RuntimeValidations do
   """
   def get_augmented_ast(command) do
     ast = Code.string_to_quoted!(command)
-    {augmented_ast, _result} = Macro.postwalk(ast, nil, &add_safe_invocation(&1, &2))
+    {augmented_ast, _result} = Macro.prewalk(ast, nil, &add_safe_invocation(&1, &2))
 
     augmented_ast
+  end
+
+  defp add_safe_invocation(
+         {:|>, outer_meta,
+          [first_param, {{:., meta, [callee, function]}, meta, remaining_params}]},
+         acc
+       ) do
+    params = [first_param | remaining_params]
+
+    elem =
+      {{:., outer_meta,
+        [
+          {:__aliases__, meta, @this_module},
+          :safe_invocation
+        ]}, meta, [callee, function, params]}
+
+    {elem, acc}
   end
 
   defp add_safe_invocation({{:., meta, [callee, function]}, outer_meta, params}, acc) do
@@ -54,18 +71,18 @@ defmodule ElixirConsole.Sandbox.RuntimeValidations do
 
   # TODO generalize to other macros from Kernel and Integer (and for other modules?)
   def safe_invocation(Kernel, :to_string, params) do
-    apply(&(Kernel.to_string(&1)), params)
+    apply(&to_string(&1), params)
   end
 
   def safe_invocation(Integer, :is_odd, params) do
     require Integer
-    apply(&(Integer.is_odd(&1)), params)
-  end
-  def safe_invocation(Integer, :is_even, params) do
-    require Integer
-    apply(&(Integer.is_even(&1)), params)
+    apply(&Integer.is_odd(&1), params)
   end
 
+  def safe_invocation(Integer, :is_even, params) do
+    require Integer
+    apply(&Integer.is_even(&1), params)
+  end
 
   def safe_invocation(callee, function, params) do
     if ElixirConsole.Sandbox.Util.is_erlang_module?(callee) do

--- a/lib/elixir_console/sandbox/runtime_validations.ex
+++ b/lib/elixir_console/sandbox/runtime_validations.ex
@@ -1,0 +1,87 @@
+defmodule ElixirConsole.Sandbox.RuntimeValidations do
+  @moduledoc """
+    This module injects code to the AST for code from untrusted sources. It
+    ensures that non-secure functions are not invoked at runtime.
+  """
+
+  @this_module Module.split(__MODULE__) |> Enum.map(&String.to_atom/1)
+  @valid_modules ElixirConsole.ElixirSafeParts.safe_elixir_modules()
+  @kernel_functions_blacklist ElixirConsole.ElixirSafeParts.unsafe_kernel_functions()
+
+  @doc """
+    Returns the AST for the given Elixir code but including invocations to
+    `safe_invocation/2` before invoking any given function (based on the
+    presence of the :. operator)
+  """
+  def get_augmented_ast(command) do
+    ast = Code.string_to_quoted!(command)
+    {augmented_ast, _result} = Macro.postwalk(ast, nil, &add_safe_invocation(&1, &2))
+
+    augmented_ast
+  end
+
+  defp add_safe_invocation({:., meta, [callee, function]}, acc) do
+    elem =
+      {:., meta,
+       [
+         {
+           {:., meta,
+            [
+              {:__aliases__, meta, @this_module},
+              :safe_invocation
+            ]},
+           meta,
+           [callee, function]
+         },
+         function
+       ]}
+
+    {elem, acc}
+  end
+
+  defp add_safe_invocation(elem, acc), do: {elem, acc}
+
+  @doc """
+    This function is meant to be invoked before calling a function (from an
+    expression with the form `foo.bar`), so the Sandbox can effectively check if
+    this invocation is considered safe. In case of success, the callee is
+    returned. In this way, this function can be inlined in the original
+    expression (like `safe_invocation(foo, bar).bar`).
+  """
+  def safe_invocation(callee, _) when callee not in @valid_modules do
+    raise "Sandbox runtime error: It is not allowed to use some Elixir modules. " <>
+            "Not allowed module attempted: #{inspect(callee)}"
+  end
+
+  def safe_invocation(Kernel, function) when function in @kernel_functions_blacklist do
+    raise "Sandbox runtime error: It is not allowed to use some Elixir modules. " <>
+            "Not allowed function attempted: #{inspect(function)}"
+  end
+
+  def safe_invocation(String, :to_atom) do
+    raise "Sandbox runtime error: String.to_atom/1 is not allowed."
+  end
+
+  def safe_invocation(callee, _function) do
+    if is_erlang_module?(callee) do
+      raise "It is not allowed to invoke non-Elixir modules. " <>
+              "Not allowed module attempted: #{inspect(callee)}"
+    else
+      callee
+    end
+  end
+
+  # TODO repeated code
+  @az_range 97..122
+
+  defp is_erlang_module?(module) when not is_atom(module), do: false
+
+  defp is_erlang_module?(module) do
+    module
+    |> to_charlist
+    |> starts_with_lowercase?
+  end
+
+  defp starts_with_lowercase?([first_char | _]) when first_char in @az_range, do: true
+  defp starts_with_lowercase?(_module_charlist), do: false
+end

--- a/lib/elixir_console/sandbox/runtime_validations.ex
+++ b/lib/elixir_console/sandbox/runtime_validations.ex
@@ -4,6 +4,8 @@ defmodule ElixirConsole.Sandbox.RuntimeValidations do
     ensures that non-secure functions are not invoked at runtime.
   """
 
+  alias ElixirConsole.Sandbox.Util
+
   @this_module __MODULE__ |> Module.split() |> Enum.map(&String.to_atom/1)
   @valid_modules ElixirConsole.ElixirSafeParts.safe_elixir_modules()
   @kernel_functions_blacklist ElixirConsole.ElixirSafeParts.unsafe_kernel_functions()
@@ -63,25 +65,11 @@ defmodule ElixirConsole.Sandbox.RuntimeValidations do
   end
 
   def safe_invocation(callee, _function) do
-    if is_erlang_module?(callee) do
+    if ElixirConsole.Sandbox.Util.is_erlang_module?(callee) do
       raise "It is not allowed to invoke non-Elixir modules. " <>
               "Not allowed module attempted: #{inspect(callee)}"
     else
       callee
     end
   end
-
-  # TODO repeated code
-  @az_range 97..122
-
-  defp is_erlang_module?(module) when not is_atom(module), do: false
-
-  defp is_erlang_module?(module) do
-    module
-    |> to_charlist
-    |> starts_with_lowercase?
-  end
-
-  defp starts_with_lowercase?([first_char | _]) when first_char in @az_range, do: true
-  defp starts_with_lowercase?(_module_charlist), do: false
 end

--- a/lib/elixir_console/sandbox/runtime_validations.ex
+++ b/lib/elixir_console/sandbox/runtime_validations.ex
@@ -125,4 +125,14 @@ defmodule ElixirConsole.Sandbox.RuntimeValidations do
       apply(callee, function, params)
     end
   end
+
+  def safe_invocation(callee, function, params) do
+    try do
+      Sentry.capture_message("safe_invocation unexpected case",
+        extra: %{callee: callee, function: function, params: params}
+      )
+    after
+      raise "Internal error. Please fill an issue at https://github.com/wyeworks/elixir_console/issues."
+    end
+  end
 end

--- a/lib/elixir_console/sandbox/util.ex
+++ b/lib/elixir_console/sandbox/util.ex
@@ -1,0 +1,16 @@
+defmodule ElixirConsole.Sandbox.Util do
+  @moduledoc false
+
+  @az_range 97..122
+
+  def is_erlang_module?(module) when not is_atom(module), do: false
+
+  def is_erlang_module?(module) do
+    module
+    |> to_charlist
+    |> starts_with_lowercase?
+  end
+
+  defp starts_with_lowercase?([first_char | _]) when first_char in @az_range, do: true
+  defp starts_with_lowercase?(_module_charlist), do: false
+end

--- a/test/elixir_console/sandbox/runtime_validations_test.exs
+++ b/test/elixir_console/sandbox/runtime_validations_test.exs
@@ -1,0 +1,44 @@
+defmodule ElixirConsole.Sandbox.RuntimeValidationsTest do
+  use ExUnit.Case, async: true
+  alias ElixirConsole.Sandbox.RuntimeValidations
+
+  test "does not make any change to the AST when no needed" do
+    command = "[1, 2, 3, 5] ++ [4, 5]"
+    {:ok, original_ast} = Code.string_to_quoted(command)
+    assert original_ast == RuntimeValidations.get_augmented_ast(command)
+  end
+
+  test "inserts an inline call when dot operator is used" do
+    command = "Enum.count([])"
+
+    {:ok, expected_ast} =
+      Code.string_to_quoted(
+        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count).count([])"
+      )
+
+    assert expected_ast == RuntimeValidations.get_augmented_ast(command)
+  end
+
+  test "inserts an inline call when pipe operator is used" do
+    command = "[] |> Enum.count"
+
+    {:ok, expected_ast} =
+      Code.string_to_quoted(
+        "[] |> ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count).count()"
+      )
+
+    assert expected_ast == RuntimeValidations.get_augmented_ast(command)
+  end
+
+  test "inserts inline calls within nested expressions" do
+    command = "Enum.count(Enum.map([1,2,3], &(&1 * 2)))"
+
+    {:ok, expected_ast} =
+      Code.string_to_quoted(
+        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count).count(" <>
+          "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :map).map([1,2,3], &(&1 * 2)))"
+      )
+
+    assert expected_ast == RuntimeValidations.get_augmented_ast(command)
+  end
+end

--- a/test/elixir_console/sandbox/runtime_validations_test.exs
+++ b/test/elixir_console/sandbox/runtime_validations_test.exs
@@ -8,7 +8,7 @@ defmodule ElixirConsole.Sandbox.RuntimeValidationsTest do
     assert original_ast == RuntimeValidations.get_augmented_ast(command)
   end
 
-  test "inserts an inline call when dot operator is used" do
+  test "replaces invocation when dot operator is used" do
     command = "Enum.count([2])"
 
     {:ok, expected_ast} =
@@ -19,39 +19,49 @@ defmodule ElixirConsole.Sandbox.RuntimeValidationsTest do
     assert expected_ast == RuntimeValidations.get_augmented_ast(command)
   end
 
-  @tag :pending
-  test "inserts an inline call when pipe operator is used" do
-    command = "[] |> Enum.count"
-
-    {:ok, expected_ast} =
-      Code.string_to_quoted(
-        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count, [[]])"
-      )
-
-    assert expected_ast == RuntimeValidations.get_augmented_ast(command)
-  end
-
-  @tag :pending
-  test "inserts inline calls within nested expressions" do
+  test "replace invocations within nested expressions" do
     command = "Enum.count(Enum.map([1,2,3], &(&1 * 2)))"
 
     {:ok, expected_ast} =
       Code.string_to_quoted(
-        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count).count(" <>
-          "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :map).map([1,2,3], &(&1 * 2)))"
+        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count, [" <>
+          "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :map, [[1,2,3], &(&1 * 2)])" <>
+          "])"
       )
 
     assert expected_ast == RuntimeValidations.get_augmented_ast(command)
   end
 
-  @tag :pending
-  test "inserts an inline call when string interpolation is used" do
-    command = "\"Hello \#{:world}\""
+  test "changes to direct invocation and replaces invocation when pipe operator is used" do
+    command = "[1,2,3] |> Enum.map(fn n -> n * 2 end) |> Enum.count"
 
     {:ok, expected_ast} =
       Code.string_to_quoted(
-        "<<\"Hello \", ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Kernel, :to_string).to_string(:world)::binary>>"
+        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count, [" <>
+          "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :map, [[1,2,3], fn n -> n * 2 end])" <>
+          "])"
       )
+
+    assert expected_ast == RuntimeValidations.get_augmented_ast(command)
+  end
+
+  test "makes a safe invocation when string interpolation is used" do
+    command = "\"Hello \#{:world}\""
+
+    expected_ast =
+      {:<<>>, [line: 1],
+       [
+         "Hello ",
+         {:"::", [line: 1],
+          [
+            {{:., [line: 1],
+              [
+                {:__aliases__, [line: 1], [:ElixirConsole, :Sandbox, :RuntimeValidations]},
+                :safe_invocation
+              ]}, [line: 1], [Kernel, :to_string, [:world]]},
+            {:binary, [line: 1], nil}
+          ]}
+       ]}
 
     assert expected_ast == RuntimeValidations.get_augmented_ast(command)
   end

--- a/test/elixir_console/sandbox/runtime_validations_test.exs
+++ b/test/elixir_console/sandbox/runtime_validations_test.exs
@@ -9,27 +9,29 @@ defmodule ElixirConsole.Sandbox.RuntimeValidationsTest do
   end
 
   test "inserts an inline call when dot operator is used" do
-    command = "Enum.count([])"
+    command = "Enum.count([2])"
 
     {:ok, expected_ast} =
       Code.string_to_quoted(
-        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count).count([])"
+        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count, [[2]])"
       )
 
     assert expected_ast == RuntimeValidations.get_augmented_ast(command)
   end
 
+  @tag :pending
   test "inserts an inline call when pipe operator is used" do
     command = "[] |> Enum.count"
 
     {:ok, expected_ast} =
       Code.string_to_quoted(
-        "[] |> ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count).count()"
+        "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count, [[]])"
       )
 
     assert expected_ast == RuntimeValidations.get_augmented_ast(command)
   end
 
+  @tag :pending
   test "inserts inline calls within nested expressions" do
     command = "Enum.count(Enum.map([1,2,3], &(&1 * 2)))"
 
@@ -37,6 +39,18 @@ defmodule ElixirConsole.Sandbox.RuntimeValidationsTest do
       Code.string_to_quoted(
         "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :count).count(" <>
           "ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Enum, :map).map([1,2,3], &(&1 * 2)))"
+      )
+
+    assert expected_ast == RuntimeValidations.get_augmented_ast(command)
+  end
+
+  @tag :pending
+  test "inserts an inline call when string interpolation is used" do
+    command = "\"Hello \#{:world}\""
+
+    {:ok, expected_ast} =
+      Code.string_to_quoted(
+        "<<\"Hello \", ElixirConsole.Sandbox.RuntimeValidations.safe_invocation(Kernel, :to_string).to_string(:world)::binary>>"
       )
 
     assert expected_ast == RuntimeValidations.get_augmented_ast(command)

--- a/test/elixir_console/sandbox_test.exs
+++ b/test/elixir_console/sandbox_test.exs
@@ -136,5 +136,17 @@ defmodule ElixirConsole.SandboxTest do
       assert Sandbox.execute("{a, b} = {[1, 2] ++ 3, [4 | 5]}", sandbox) ==
                {:success, {{[1, 2 | 3], [4 | 5]}, expected_sandbox}}
     end
+
+    test "works with nested structures", %{sandbox: sandbox} do
+      users = [
+        john: %{name: "John", age: 27, languages: ["Erlang", "Ruby", "Elixir"]},
+        mary: %{name: "Mary", age: 29, languages: ["Elixir", "F#", "Clojure"]}
+      ]
+
+      initial_and_expected_sandbox = %Sandbox{sandbox | bindings: [users: users]}
+
+      assert Sandbox.execute("users[:john].age", initial_and_expected_sandbox) ==
+               {:success, {27, initial_and_expected_sandbox}}
+    end
   end
 end

--- a/test/elixir_console/sandbox_test.exs
+++ b/test/elixir_console/sandbox_test.exs
@@ -148,5 +148,28 @@ defmodule ElixirConsole.SandboxTest do
       assert Sandbox.execute("users[:john].age", initial_and_expected_sandbox) ==
                {:success, {27, initial_and_expected_sandbox}}
     end
+
+    test "works when using Kernel.put_in/2 and friends", %{sandbox: sandbox} do
+      users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
+      initial_and_expected_sandbox = %Sandbox{sandbox | bindings: [users: users]}
+
+      assert Sandbox.execute("put_in(users[\"john\"][:age], 28)", initial_and_expected_sandbox) ==
+               {:success,
+                {%{"john" => %{age: 28}, "meg" => %{age: 23}}, initial_and_expected_sandbox}}
+
+      assert Sandbox.execute(
+               "update_in(users[\"john\"].age, &(&1 + 1))",
+               initial_and_expected_sandbox
+             ) ==
+               {:success,
+                {%{"john" => %{age: 28}, "meg" => %{age: 23}}, initial_and_expected_sandbox}}
+
+      assert Sandbox.execute(
+               "get_and_update_in(users[\"john\"].age, &{&1, &1 + 1})",
+               initial_and_expected_sandbox
+             ) ==
+               {:success,
+                {{27, %{"john" => %{age: 28}, "meg" => %{age: 23}}}, initial_and_expected_sandbox}}
+    end
   end
 end

--- a/test/elixir_console/sandbox_test.exs
+++ b/test/elixir_console/sandbox_test.exs
@@ -73,4 +73,12 @@ defmodule ElixirConsole.SandboxTest do
 
     assert {:success, {3, _}} = Sandbox.execute("1 + 2", sandbox)
   end
+
+  test "returns a runtime error when about to invoke an unsafe function", %{sandbox: sandbox} do
+    assert {:error,
+            {"%RuntimeError{message: \"Sandbox runtime error: " <>
+               "It is not allowed to use some Elixir modules. " <>
+               "Not allowed module attempted: File\"}",
+             _}} = Sandbox.execute(":\"Elixir.File\".cwd()", sandbox)
+  end
 end

--- a/test/elixir_console/sandbox_test.exs
+++ b/test/elixir_console/sandbox_test.exs
@@ -6,79 +6,111 @@ defmodule ElixirConsole.SandboxTest do
     [sandbox: Sandbox.init()]
   end
 
-  test "runs a basic command", %{sandbox: sandbox} do
-    expected_sandbox = %Sandbox{sandbox | bindings: []}
+  describe "Sandbox success and error cases" do
+    test "runs a basic command", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: []}
 
-    assert Sandbox.execute("1 + 2", sandbox) == {:success, {3, expected_sandbox}}
+      assert Sandbox.execute("1 + 2", sandbox) == {:success, {3, expected_sandbox}}
+    end
+
+    test "adds a new binding", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: [a: 3]}
+
+      assert Sandbox.execute("a = 1 + 2", sandbox) == {:success, {3, expected_sandbox}}
+    end
+
+    test "updates an existing binding", %{sandbox: sandbox} do
+      sandbox = %Sandbox{sandbox | bindings: [a: "foo"]}
+      expected_sandbox = %Sandbox{sandbox | bindings: [a: 3]}
+
+      assert Sandbox.execute("a = 1 + 2", sandbox) == {:success, {3, expected_sandbox}}
+    end
+
+    test "keeps existing bindings", %{sandbox: sandbox} do
+      sandbox = %Sandbox{sandbox | bindings: [a: "foo"]}
+      expected_sandbox = %Sandbox{sandbox | bindings: [a: "foo"]}
+
+      assert Sandbox.execute("1 + 2", sandbox) == {:success, {3, expected_sandbox}}
+    end
+
+    test "reports excessive memory usage", %{sandbox: sandbox} do
+      assert {:error, {"The command used more memory than allowed", _}} =
+               Sandbox.execute("for i <- 1..70_000, do: i", sandbox)
+    end
+
+    test "reports excessive memory usage with custom memory limit", %{sandbox: sandbox} do
+      assert {:error, {"The command used more memory than allowed", _}} =
+               Sandbox.execute("for i <- 1..100_000_000, do: i", sandbox, max_memory_kb: 10)
+    end
+
+    test "reports excessive time spent on the execution", %{sandbox: sandbox} do
+      assert {:error, {"The command was cancelled due to timeout", _}} =
+               Sandbox.execute("Enum.each(1..100_000_000, &(&1))", sandbox, timeout: 50)
+    end
+
+    test "refuses to run unsafe code", %{sandbox: sandbox} do
+      assert {:error,
+              {"It is not allowed to use some Elixir modules. " <>
+                 "Not allowed modules attempted: [:File]",
+               _}} = Sandbox.execute("File.cwd()", sandbox)
+    end
+
+    test "refuses to run a very large command", %{sandbox: sandbox} do
+      assert {:error, {"Command is too long. Try running a shorter piece of code.", _}} =
+               Sandbox.execute(
+                 String.duplicate("a", 600),
+                 sandbox
+               )
+    end
+
+    test "allows to run more commands after excessive memory usage error", %{sandbox: sandbox} do
+      {:error, {_, sandbox}} = Sandbox.execute("for i <- 1..70_000, do: i", sandbox)
+
+      assert {:success, {3, _}} = Sandbox.execute("1 + 2", sandbox)
+    end
+
+    test "allows to run more commands after timeout error", %{sandbox: sandbox} do
+      {:error, {_, sandbox}} = Sandbox.execute(":timer.sleep(100)", sandbox, timeout: 50)
+
+      assert {:success, {3, _}} = Sandbox.execute("1 + 2", sandbox)
+    end
+
+    test "returns a runtime error when about to invoke an unsafe function", %{sandbox: sandbox} do
+      assert {:error,
+              {"%RuntimeError{message: \"Sandbox runtime error: " <>
+                 "It is not allowed to use some Elixir modules. " <>
+                 "Not allowed module attempted: File\"}",
+               _}} = Sandbox.execute(":\"Elixir.File\".cwd()", sandbox)
+    end
   end
 
-  test "adds a new binding", %{sandbox: sandbox} do
-    expected_sandbox = %Sandbox{sandbox | bindings: [a: 3]}
+  describe "Elixir functionality that is supported by the console" do
+    test "works with string interpolation", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: []}
 
-    assert Sandbox.execute("a = 1 + 2", sandbox) == {:success, {3, expected_sandbox}}
-  end
+      assert Sandbox.execute("\"Hello \#{:world}\"", sandbox) ==
+               {:success, {"Hello world", expected_sandbox}}
+    end
 
-  test "updates an existing binding", %{sandbox: sandbox} do
-    sandbox = %Sandbox{sandbox | bindings: [a: "foo"]}
-    expected_sandbox = %Sandbox{sandbox | bindings: [a: 3]}
+    test "works with pipe operator", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: []}
 
-    assert Sandbox.execute("a = 1 + 2", sandbox) == {:success, {3, expected_sandbox}}
-  end
+      assert Sandbox.execute("[1,2,3] |> Enum.filter(fn n -> n > 2 end) |> Enum.count", sandbox) ==
+               {:success, {1, expected_sandbox}}
+    end
 
-  test "keeps existing bindings", %{sandbox: sandbox} do
-    sandbox = %Sandbox{sandbox | bindings: [a: "foo"]}
-    expected_sandbox = %Sandbox{sandbox | bindings: [a: "foo"]}
+    test "works with tuples in pattern matching", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: [a: :hello, b: "world", c: 42]}
 
-    assert Sandbox.execute("1 + 2", sandbox) == {:success, {3, expected_sandbox}}
-  end
+      assert Sandbox.execute("{a, b, c} = {:hello, \"world\", 42}", sandbox) ==
+               {:success, {{:hello, "world", 42}, expected_sandbox}}
+    end
 
-  test "reports excessive memory usage", %{sandbox: sandbox} do
-    assert {:error, {"The command used more memory than allowed", _}} =
-             Sandbox.execute("for i <- 1..70_000, do: i", sandbox)
-  end
+    test "works with list in pattern matching", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: [head: 1, tail: [2, 3]]}
 
-  test "reports excessive memory usage with custom memory limit", %{sandbox: sandbox} do
-    assert {:error, {"The command used more memory than allowed", _}} =
-             Sandbox.execute("for i <- 1..100_000_000, do: i", sandbox, max_memory_kb: 10)
-  end
-
-  test "reports excessive time spent on the execution", %{sandbox: sandbox} do
-    assert {:error, {"The command was cancelled due to timeout", _}} =
-             Sandbox.execute("Enum.each(1..100_000_000, &(&1))", sandbox, timeout: 50)
-  end
-
-  test "refuses to run unsafe code", %{sandbox: sandbox} do
-    assert {:error,
-            {"It is not allowed to use some Elixir modules. " <>
-               "Not allowed modules attempted: [:File]",
-             _}} = Sandbox.execute("File.cwd()", sandbox)
-  end
-
-  test "refuses to run a very large command", %{sandbox: sandbox} do
-    assert {:error, {"Command is too long. Try running a shorter piece of code.", _}} =
-             Sandbox.execute(
-               String.duplicate("a", 600),
-               sandbox
-             )
-  end
-
-  test "allows to run more commands after excessive memory usage error", %{sandbox: sandbox} do
-    {:error, {_, sandbox}} = Sandbox.execute("for i <- 1..70_000, do: i", sandbox)
-
-    assert {:success, {3, _}} = Sandbox.execute("1 + 2", sandbox)
-  end
-
-  test "allows to run more commands after timeout error", %{sandbox: sandbox} do
-    {:error, {_, sandbox}} = Sandbox.execute(":timer.sleep(100)", sandbox, timeout: 50)
-
-    assert {:success, {3, _}} = Sandbox.execute("1 + 2", sandbox)
-  end
-
-  test "returns a runtime error when about to invoke an unsafe function", %{sandbox: sandbox} do
-    assert {:error,
-            {"%RuntimeError{message: \"Sandbox runtime error: " <>
-               "It is not allowed to use some Elixir modules. " <>
-               "Not allowed module attempted: File\"}",
-             _}} = Sandbox.execute(":\"Elixir.File\".cwd()", sandbox)
+      assert Sandbox.execute("[head | tail] = [1, 2, 3]", sandbox) ==
+               {:success, {[1, 2, 3], expected_sandbox}}
+    end
   end
 end

--- a/test/elixir_console/sandbox_test.exs
+++ b/test/elixir_console/sandbox_test.exs
@@ -112,5 +112,29 @@ defmodule ElixirConsole.SandboxTest do
       assert Sandbox.execute("[head | tail] = [1, 2, 3]", sandbox) ==
                {:success, {[1, 2, 3], expected_sandbox}}
     end
+
+    test "works with basic if blocks", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: []}
+
+      assert Sandbox.execute("if true, do: :great", sandbox) ==
+               {:success, {:great, expected_sandbox}}
+
+      assert Sandbox.execute("if false, do: :great, else: :bad", sandbox) ==
+               {:success, {:bad, expected_sandbox}}
+    end
+
+    test "works with Bitwise macros (without the need to use the module)", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: []}
+
+      assert Sandbox.execute("1 &&& 1", sandbox) ==
+               {:success, {1, expected_sandbox}}
+    end
+
+    test "works with improper lists", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: [a: [1, 2 | 3], b: [4 | 5]]}
+
+      assert Sandbox.execute("{a, b} = {[1, 2] ++ 3, [4 | 5]}", sandbox) ==
+               {:success, {{[1, 2 | 3], [4 | 5]}, expected_sandbox}}
+    end
   end
 end


### PR DESCRIPTION
There are a certain number of cases where it is impossible to detect non-secure function invocations by only checking the code AST. For this reason, we are adding a way to modify the code AST before execution.

With this new approach, an internal function of the Sandbox is going to be executed prior to the user code invocation, resulting in a runtime error if the module or module/function to invocation is not included in our whitelists.