### PR TITLE
Prevent atoms creation by using interpolation with the sigil_w

### DIFF
--- a/lib/elixir_console/sandbox/exclude_conversion_to_atoms.ex
+++ b/lib/elixir_console/sandbox/exclude_conversion_to_atoms.ex
@@ -11,20 +11,32 @@ defmodule ElixirConsole.Sandbox.ExcludeConversionToAtoms do
   def validate(ast) do
     {_ast, result} = Macro.prewalk(ast, :ok, &valid?(&1, &2))
 
-    if result == :error do
-      {:error,
-       "It is not allowed to programmatically convert to atoms. " <>
-         "Consider using String.to_existing_atom/1"}
-    else
-      :ok
+    case result do
+      :to_atom_error ->
+        {:error,
+         "It is not allowed to programmatically convert to atoms. " <>
+           "Consider using String.to_existing_atom/1"}
+
+      :atom_modifier_in_sigils ->
+        {:error,
+         "It is not allowed to programmatically convert to atoms. " <>
+           "For this reason, the `a` modifier is not allowed when using ~w. " <>
+           "Instead, try using ~W since it does not interpolate the content"}
+
+      :ok ->
+        :ok
     end
   end
 
-  defp valid?(elem, :error), do: {elem, :error}
+  defp valid?(elem, result) when result != :ok, do: {elem, result}
 
   defp valid?({:., _, [{:__aliases__, _, [module]}, function]} = elem, _acc)
        when function == :to_atom and module in [:String, :List] do
-    {elem, :error}
+    {elem, :to_atom_error}
+  end
+
+  defp valid?({:sigil_w, _, [_, 'a']} = elem, _acc) do
+    {elem, :atom_modifier_in_sigils}
   end
 
   defp valid?(elem, acc), do: {elem, acc}

--- a/test/elixir_console/sandbox/command_validator_test.exs
+++ b/test/elixir_console/sandbox/command_validator_test.exs
@@ -35,6 +35,14 @@ defmodule ElixirConsole.Sandbox.CommandValidatorTest do
       assert :ok == CommandValidator.safe_command?("\"foo \#{10} bar\"")
     end
 
+    test "returns :ok when using ~w without the atoms modifier" do
+      assert :ok == CommandValidator.safe_command?("~w(\#{Enum.random(1..10)})")
+    end
+
+    test "returns :ok when using ~W and atoms modifier" do
+      assert :ok == CommandValidator.safe_command?("~W(foo bar)a")
+    end
+
     test "returns :error when using an invalid Kernel function" do
       assert {:error,
               "It is allowed to invoke only safe Kernel functions. " <>
@@ -75,6 +83,14 @@ defmodule ElixirConsole.Sandbox.CommandValidatorTest do
               "It is not allowed to programmatically convert to atoms. " <>
                 "Consider using String.to_existing_atom/1"} ==
                CommandValidator.safe_command?("String.to_atom(\"foo\")")
+    end
+
+    test "returns :error when attempting to use sigils that create atoms dynamically" do
+      assert {:error,
+              "It is not allowed to programmatically convert to atoms. " <>
+                "For this reason, the `a` modifier is not allowed when using ~w. " <>
+                "Instead, try using ~W since it does not interpolate the content"} ==
+               CommandValidator.safe_command?("~w(\#{Enum.random(1..10)})a")
     end
   end
 end


### PR DESCRIPTION
It was possible to dynamically create a significant number of atoms using the sigil_w with the atom modifier and combined with string interpolation.