### PR TITLE
Fix issue with function capturing

### DIFF
--- a/lib/elixir_console/sandbox/util.ex
+++ b/lib/elixir_console/sandbox/util.ex
@@ -11,6 +11,14 @@ defmodule ElixirConsole.Sandbox.Util do
     |> starts_with_lowercase?
   end
 
+  # Based on https://stackoverflow.com/a/32002566/2819826
+  def random_atom(length) do
+    :crypto.strong_rand_bytes(length)
+    |> Base.url_encode64()
+    |> binary_part(0, length)
+    |> String.to_atom()
+  end
+
   defp starts_with_lowercase?([first_char | _]) when first_char in @az_range, do: true
   defp starts_with_lowercase?(_module_charlist), do: false
 end

--- a/test/elixir_console/sandbox/runtime_validations_test.exs
+++ b/test/elixir_console/sandbox/runtime_validations_test.exs
@@ -65,4 +65,11 @@ defmodule ElixirConsole.Sandbox.RuntimeValidationsTest do
 
     assert expected_ast == RuntimeValidations.get_augmented_ast(command)
   end
+
+  test "does not make changes when dot operator exists but it is not an invocation" do
+    command = "&Kernel.+/2"
+    {:ok, expected_ast} = Code.string_to_quoted("&Kernel.+/2")
+
+    assert expected_ast == RuntimeValidations.get_augmented_ast(command)
+  end
 end

--- a/test/elixir_console/sandbox_test.exs
+++ b/test/elixir_console/sandbox_test.exs
@@ -226,5 +226,12 @@ defmodule ElixirConsole.SandboxTest do
                {:success,
                 {{27, %{"john" => %{age: 28}, "meg" => %{age: 23}}}, initial_and_expected_sandbox}}
     end
+
+    test "works with function capturing", %{sandbox: sandbox} do
+      expected_sandbox = %Sandbox{sandbox | bindings: []}
+
+      assert Sandbox.execute("Enum.reduce([1,2,3,4,5], &Kernel.+/2)", sandbox) ==
+               {:success, {15, expected_sandbox}}
+    end
   end
 end


### PR DESCRIPTION
It fixes #76 by considering the particular case of the dot operator when used for function capturing.
Sections of the AST using function capturing is not modified after processing it to add the calls to `safe_invocation`.

Note we were forced to walk the AST tree in a "post-walk" manner, in addition to the original "pre-walk" callback we already had.