### PR TITLE
Set target component that will handle events

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,7 +26,7 @@ Hooks.CommandInput = {
     const input = document.getElementById('commandInput');
     const sendCursorPosition = e => {
       if (input.selectionStart === input.selectionEnd) {
-        this.pushEvent('caret-position', { position: input.selectionEnd });
+        this.pushEventTo('#commandInput', 'caret-position', { position: input.selectionEnd });
       }
     };
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,7 +22,6 @@ import LiveSocket from 'phoenix_live_view';
 let Hooks = {};
 Hooks.CommandInput = {
   mounted() {
-    const pushEvent = this.pushEvent;
     const input = document.getElementById('commandInput');
     const sendCursorPosition = e => {
       if (input.selectionStart === input.selectionEnd) {

--- a/lib/elixir_console_web/templates/console/command_input.html.leex
+++ b/lib/elixir_console_web/templates/console/command_input.html.leex
@@ -1,4 +1,4 @@
-<form phx-submit="execute" id="command_input">
+<form phx-submit="execute" id="command_input" phx-target="#command_input">
   <div class="text-gray-300 font-medium flex bg-teal-700 p-2">
     <%= print_prompt() %>
     <input
@@ -8,6 +8,7 @@
       autocomplete="off"
       name="command"
       phx-keydown="suggest"
+      phx-target="#commandInput"
       phx-hook="CommandInput"
       data-input_value="<%= @input_value %>"
       data-caret_position="<%= @caret_position %>"

--- a/lib/elixir_console_web/views/console/history_view.ex
+++ b/lib/elixir_console_web/views/console/history_view.ex
@@ -33,6 +33,7 @@ defmodule ElixirConsoleWeb.Console.HistoryView do
     phx-value-header="<%= header %>"
     phx-value-doc="<%= docs %>"
     phx-value-link="<%= link %>"
+    phx-target="#commandOutput"
     class="<%= inline_help_class_for(function_or_operator) %>"
     ><%= part %></span>}
   end


### PR DESCRIPTION
Fixes #80 

In order to define event handlers in components we must set the `phx-target`, otherwise the event will try to be handled by the parent LiveView which after the latest refactor, it doesn't implement `handle_event/3` anymore.
Same happens when using `pushEvent` which will be handled by the LiveView. In this case, the fix is to use `pushEventTo` and pass a selector to something that is rendered by the LiveComponent so it gets handled properly.

All this changed slightly in latest versions of LiveView, making it a bit more straightforward, but for the current version this is the fix.