### PR TITLE
Fix caret wrongly being repositioned after TAB key

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -19,7 +19,7 @@ import 'phoenix_html';
 import {Socket} from 'phoenix';
 import LiveSocket from 'phoenix_live_view';
 
-const TAB_KEYCODE = 9
+const TAB_KEYCODE = 9;
 
 let Hooks = {};
 Hooks.CommandInput = {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -19,13 +19,15 @@ import 'phoenix_html';
 import {Socket} from 'phoenix';
 import LiveSocket from 'phoenix_live_view';
 
+const TAB_KEYCODE = 9
+
 let Hooks = {};
 Hooks.CommandInput = {
   mounted() {
     const input = document.getElementById('commandInput');
     const sendCursorPosition = e => {
       if (input.selectionStart === input.selectionEnd) {
-        if (e.keyCode !== 9) {
+        if (e.keyCode !== TAB_KEYCODE) {
           this.pushEventTo('#commandInput', 'caret-position', { position: input.selectionEnd });
         }
       }
@@ -54,7 +56,7 @@ liveSocket.connect();
 document.addEventListener('DOMContentLoaded', function(event) {
   let input = document.getElementById('commandInput');
   input.addEventListener('keydown', function(e) {
-    if (e.keyCode === 9) {
+    if (e.keyCode === TAB_KEYCODE) {
       e.preventDefault();
     }
   }, true);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,7 +25,9 @@ Hooks.CommandInput = {
     const input = document.getElementById('commandInput');
     const sendCursorPosition = e => {
       if (input.selectionStart === input.selectionEnd) {
-        this.pushEventTo('#commandInput', 'caret-position', { position: input.selectionEnd });
+        if (e.keyCode !== 9) {
+          this.pushEventTo('#commandInput', 'caret-position', { position: input.selectionEnd });
+        }
       }
     };
 


### PR DESCRIPTION
The root of the issue was that two events were being sent for the same TAB key press, and depending on the order they're received the final state would be different.

It was seen only in staging because in fast local connections the second event always arrives last and that leaves the state in the expected shape.

To reproduce this locally I added `:timer.sleep(100)` in the handle_event functions for the `caret-position` and `suggest` events.