### PR TITLE
Enable automatic update PRs for outdated mix deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Proposal is to start small, just doing this for mix deps and limit to 2 opened PRs for now.
We can tune later on based on experience.