### PR TITLE
Fix clear input

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -41,6 +41,13 @@ Hooks.CommandInput = {
     const newValue = this.el.getAttribute('data-input_value');
     const newCaretPosition = parseInt(this.el.getAttribute('data-caret_position'));
 
+    const resetInput = this.el.dataset.reset_input;
+    if (resetInput === 'true') {
+      this.el.value = '';
+      this.el.setSelectionRange(0, 0);
+      this.pushEventTo('#commandInput', 'input-reset');
+    }
+
     if (newValue !== '') {
       this.el.value = newValue;
       this.el.setSelectionRange(newCaretPosition, newCaretPosition);

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -19,7 +19,8 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
        socket,
        history_counter: 0,
        input_value: "",
-       caret_position: 0
+       caret_position: 0,
+       reset_input: false
      )}
   end
 
@@ -68,9 +69,13 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
     {:noreply, assign(socket, caret_position: position)}
   end
 
+  def handle_event("input-reset", _, socket) do
+    {:noreply, assign(socket, reset_input: false)}
+  end
+
   def handle_event("execute", %{"command" => command}, socket) do
     send(self(), {:execute_command, command})
-    {:noreply, socket}
+    {:noreply, assign(socket, reset_input: true)}
   end
 
   defp get_previous_history_entry([], _counter), do: {[], 0}

--- a/lib/elixir_console_web/live/console_live/command_input_component.html.leex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.html.leex
@@ -12,6 +12,7 @@
       phx-hook="CommandInput"
       data-input_value="<%= @input_value %>"
       data-caret_position="<%= @caret_position %>"
+      data-reset_input="<%= @reset_input %>"
     />
   </div>
 </form>


### PR DESCRIPTION
The input was not being cleared after executing a command.
This attempts to fix this issue by maintaining in the state a property indicating if the input should be cleared.