### PR TITLE
Stop syncing caret on the server

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,20 +23,6 @@ const TAB_KEYCODE = 9;
 
 let Hooks = {};
 Hooks.CommandInput = {
-  mounted() {
-    const input = document.getElementById('commandInput');
-    const sendCursorPosition = e => {
-      if (input.selectionStart === input.selectionEnd) {
-        if (e.keyCode !== TAB_KEYCODE) {
-          this.pushEventTo('#commandInput', 'caret-position', { position: input.selectionEnd });
-        }
-      }
-    };
-
-    ['keyup', 'click', 'focus'].forEach(event => {
-      input.addEventListener(event, sendCursorPosition, true);
-    });
-  },
   updated() {
     const newValue = this.el.getAttribute('data-input_value');
     const newCaretPosition = parseInt(this.el.getAttribute('data-caret_position'));

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -42,7 +42,7 @@ Hooks.CommandInput = {
 };
 
 let csrfToken = document.querySelector('meta[name=\'csrf-token\']').getAttribute('content');
-/* eslint-disable-next-line camelcase */
+/* eslint-disable camelcase */
 let liveSocket = new LiveSocket(
   '/live',
   Socket,
@@ -56,6 +56,7 @@ let liveSocket = new LiveSocket(
     }
   }
 );
+/* eslint-enable camelcase */
 liveSocket.connect();
 
 document.addEventListener('DOMContentLoaded', function(event) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -57,7 +57,19 @@ Hooks.CommandInput = {
 
 let csrfToken = document.querySelector('meta[name=\'csrf-token\']').getAttribute('content');
 /* eslint-disable-next-line camelcase */
-let liveSocket = new LiveSocket('/live', Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}});
+let liveSocket = new LiveSocket(
+  '/live',
+  Socket,
+  {
+    hooks: Hooks,
+    params: {_csrf_token: csrfToken},
+    metadata: {
+      keydown: (e, el) => {
+        return {caret_position: el.selectionEnd};
+      }
+    }
+  }
+);
 liveSocket.connect();
 
 document.addEventListener('DOMContentLoaded', function(event) {

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -24,12 +24,22 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
      )}
   end
 
+  defp ensure_number(value) when is_number(value),
+    do: value
+
+  defp ensure_number(value), do: String.to_integer(value)
+
   def handle_event(
         "suggest",
         %{"key" => @tab_keycode, "value" => value, "caret_position" => caret_position},
         socket
       ) do
     %{bindings: bindings} = socket.assigns
+
+    # When testing this event using render_keydown/up, even if the metadata is defined as a number,
+    # we're receiving the value here as a string.
+    # This happens only in tests though, when running the server we correctly receive it as a number.
+    caret_position = ensure_number(caret_position)
 
     case Autocomplete.get_suggestions(value, caret_position, bindings) do
       [suggestion] ->

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -54,15 +54,27 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
   def handle_event("suggest", %{"key" => @up_keycode}, socket) do
     %{history_counter: counter, history: history} = socket.assigns
     {input_value, new_counter} = get_previous_history_entry(history, counter)
+    new_caret_position = String.length(input_value)
 
-    {:noreply, assign(socket, input_value: input_value, history_counter: new_counter)}
+    {:noreply,
+     assign(socket,
+       input_value: input_value,
+       history_counter: new_counter,
+       caret_position: new_caret_position
+     )}
   end
 
   def handle_event("suggest", %{"key" => @down_keycode}, socket) do
     %{history_counter: counter, history: history} = socket.assigns
     {input_value, new_counter} = get_next_history_entry(history, counter)
+    new_caret_position = String.length(input_value)
 
-    {:noreply, assign(socket, input_value: input_value, history_counter: new_counter)}
+    {:noreply,
+     assign(socket,
+       input_value: input_value,
+       history_counter: new_counter,
+       caret_position: new_caret_position
+     )}
   end
 
   def handle_event("suggest", _key, socket) do
@@ -78,23 +90,23 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
     {:noreply, assign(socket, reset_input: true)}
   end
 
-  defp get_previous_history_entry([], _counter), do: {[], 0}
+  defp get_previous_history_entry([], _counter), do: {"", 0}
 
   defp get_previous_history_entry(history, counter) when counter + 1 < length(history) do
-    {[Enum.at(history, counter + 1)], counter + 1}
+    {Enum.at(history, counter + 1), counter + 1}
   end
 
   defp get_previous_history_entry(history, counter) do
-    {[List.last(history)], counter}
+    {List.last(history), counter}
   end
 
-  defp get_next_history_entry([], _counter), do: {[], 0}
+  defp get_next_history_entry([], _counter), do: {"", 0}
 
   defp get_next_history_entry(history, counter) when counter > 0 do
-    {[Enum.at(history, counter - 1)], counter - 1}
+    {Enum.at(history, counter - 1), counter - 1}
   end
 
   defp get_next_history_entry(history, _counter) do
-    {[List.first(history)], 0}
+    {List.first(history), 0}
   end
 end

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -24,8 +24,12 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
      )}
   end
 
-  def handle_event("suggest", %{"key" => @tab_keycode, "value" => value}, socket) do
-    %{caret_position: caret_position, bindings: bindings} = socket.assigns
+  def handle_event(
+        "suggest",
+        %{"key" => @tab_keycode, "value" => value, "caret_position" => caret_position},
+        socket
+      ) do
+    %{bindings: bindings} = socket.assigns
 
     case Autocomplete.get_suggestions(value, caret_position, bindings) do
       [suggestion] ->

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -69,10 +69,6 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
     {:noreply, assign(socket, history_counter: -1, input_value: "")}
   end
 
-  def handle_event("caret-position", %{"position" => position}, socket) do
-    {:noreply, assign(socket, caret_position: position)}
-  end
-
   def handle_event("input-reset", _, socket) do
     {:noreply, assign(socket, reset_input: false)}
   end

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -103,8 +103,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-      render_hook(input, :"caret-position", %{"position" => 7})
-      render_keydown(input, %{"key" => "Tab", "value" => "Enum.co"})
+      render_keydown(input, %{"key" => "Tab", "value" => "Enum.co", "caret_position" => 7})
 
       html = render(view)
 
@@ -115,8 +114,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-      render_hook(input, :"caret-position", %{"position" => 9})
-      render_keydown(input, %{"key" => "Tab", "value" => "Enum.conc"})
+      render_keydown(input, %{"key" => "Tab", "value" => "Enum.conc", "caret_position" => 9})
 
       html = render(view)
 
@@ -130,8 +128,12 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-      render_hook(input, :"caret-position", %{"position" => 7})
-      render_keydown(input, %{"key" => "Tab", "value" => "Enum.co([1,2]) - 2"})
+
+      render_keydown(input, %{
+        "key" => "Tab",
+        "value" => "Enum.co([1,2]) - 2",
+        "caret_position" => 7
+      })
 
       html = render(view)
 
@@ -142,8 +144,13 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-      render_hook(input, :"caret-position", %{"position" => 9})
-      html = render_keydown(input, %{"key" => "Tab", "value" => "Enum.conc([1,2], [3])"})
+
+      html =
+        render_keydown(input, %{
+          "key" => "Tab",
+          "value" => "Enum.conc([1,2], [3])",
+          "caret_position" => 9
+        })
 
       assert html =~ ~r/\<input .* data-input_value\="Enum.concat\(\[1,2\], \[3\]\)"/
       assert html =~ ~r/\<input .* data-caret_position\="11"/


### PR DESCRIPTION
Now that we're able to get the caret position specifically as metadata on the suggest events we can stop syncing the caret position every time it changes on the client.
We still keep it synced on the client when it changes on the server.

This PR also fixes the problem where the caret was not being placed at the end after cycling through the history.