### PR TITLE
Attempt to improve semantics of event name

### DIFF
--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -24,7 +24,7 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
      )}
   end
 
-  def handle_event("suggest", %{"key" => @tab_keycode, "value" => value}, socket) do
+  def handle_event("keydown", %{"key" => @tab_keycode, "value" => value}, socket) do
     %{caret_position: caret_position, bindings: bindings} = socket.assigns
 
     case Autocomplete.get_suggestions(value, caret_position, bindings) do
@@ -47,21 +47,21 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
     end
   end
 
-  def handle_event("suggest", %{"key" => @up_keycode}, socket) do
+  def handle_event("keydown", %{"key" => @up_keycode}, socket) do
     %{history_counter: counter, history: history} = socket.assigns
     {input_value, new_counter} = get_previous_history_entry(history, counter)
 
     {:noreply, assign(socket, input_value: input_value, history_counter: new_counter)}
   end
 
-  def handle_event("suggest", %{"key" => @down_keycode}, socket) do
+  def handle_event("keydown", %{"key" => @down_keycode}, socket) do
     %{history_counter: counter, history: history} = socket.assigns
     {input_value, new_counter} = get_next_history_entry(history, counter)
 
     {:noreply, assign(socket, input_value: input_value, history_counter: new_counter)}
   end
 
-  def handle_event("suggest", _key, socket) do
+  def handle_event("keydown", _key, socket) do
     {:noreply, assign(socket, history_counter: -1, input_value: "")}
   end
 

--- a/lib/elixir_console_web/live/console_live/command_input_component.html.leex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.html.leex
@@ -7,7 +7,7 @@
       class="ml-2 bg-transparent flex-1 outline-none"
       autocomplete="off"
       name="command"
-      phx-keydown="suggest"
+      phx-keydown="keydown"
       phx-target="#command_input"
       phx-hook="CommandInput"
       data-input_value="<%= @input_value %>"


### PR DESCRIPTION
Motivation coming from the fact I was a bit confused by an event called "suggest" was being used to handle both the suggestions and the expression history.