### PR TITLE
Fail if mix.compile warnings in CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Compile assets
       run: cd assets && ./node_modules/.bin/webpack --mode development
     - name: Compile elixir
-      run: MIX_ENV=test mix compile
+      run: MIX_ENV=test mix compile --force --warnings-as-errors
     - name: Run tests
       run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -28,7 +28,9 @@ jobs:
       run: yarn --cwd assets
     - name: Compile assets
       run: cd assets && ./node_modules/.bin/webpack --mode development
-    - name: Compile elixir
+    - name: Compile elixir deps
+      run: MIX_ENV=test mix deps.compile
+    - name: Compile elixir project
       run: MIX_ENV=test mix compile --force --warnings-as-errors
     - name: Run tests
       run: mix test


### PR DESCRIPTION
Can help catch and make sure we fix warnings for tasks like #115.

Inspired by https://dashbit.co/blog/tests-with-warnings-as-errors.