### PR TITLE
Handle all commandInput events in the hook

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -31,7 +31,7 @@ Hooks.CommandInput = {
         this.pushEventTo(
           '#commandInput',
           'suggest',
-          {'key': e.code, 'value': el.value, 'caret_position': el.selectionEnd}
+          {'value': el.value, 'caret_position': el.selectionEnd}
         );
       } else if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
         this.pushEventTo('#commandInput', 'cycle_history', { key: e.code });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -30,13 +30,13 @@ Hooks.CommandInput = {
       if (e.code === 'Tab') {
         this.pushEventTo(
           '#commandInput',
-          'keydown',
+          'suggest',
           {'key': e.code, 'value': el.value, 'caret_position': el.selectionEnd}
         );
       } else if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
-        this.pushEventTo('#commandInput', 'keydown', { key: e.code });
+        this.pushEventTo('#commandInput', 'cycle_history', { key: e.code });
       } else {
-        this.pushEventTo('#commandInput', 'keydown', {});
+        this.pushEventTo('#commandInput', 'reset_history', {});
       }
     });
   },

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33,8 +33,10 @@ Hooks.CommandInput = {
           'suggest',
           {'value': el.value, 'caret_position': el.selectionEnd}
         );
-      } else if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
-        this.pushEventTo('#commandInput', 'cycle_history', { key: e.code });
+      } else if (e.code === 'ArrowUp') {
+        this.pushEventTo('#commandInput', 'cycle_history_up');
+      } else if (e.code === 'ArrowDown') {
+        this.pushEventTo('#commandInput', 'cycle_history_down');
       } else {
         this.pushEventTo('#commandInput', 'reset_history', {});
       }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,19 @@ Hooks.CommandInput = {
     this.handleEvent('reset', () => {
       el.value = '';
     });
+    el.addEventListener('keydown', (e) => {
+      if (e.code === 'Tab') {
+        this.pushEventTo(
+          '#commandInput',
+          'keydown',
+          {'key': e.code, 'value': el.value, 'caret_position': el.selectionEnd}
+        );
+      } else if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
+        this.pushEventTo('#commandInput', 'keydown', { key: e.code });
+      } else {
+        this.pushEventTo('#commandInput', 'keydown', {});
+      }
+    });
   },
   updated() {
     const newValue = this.el.dataset.input_value;

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -29,7 +29,7 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
   defp ensure_number(value), do: String.to_integer(value)
 
   def handle_event(
-        "keydown",
+        "suggest",
         %{"key" => @tab_keycode, "value" => value, "caret_position" => caret_position},
         socket
       ) do
@@ -60,7 +60,7 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
     end
   end
 
-  def handle_event("keydown", %{"key" => @up_keycode}, socket) do
+  def handle_event("cycle_history", %{"key" => @up_keycode}, socket) do
     %{history_counter: counter, history: history} = socket.assigns
     {input_value, new_counter} = get_previous_history_entry(history, counter)
     new_caret_position = String.length(input_value)
@@ -73,7 +73,7 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
      )}
   end
 
-  def handle_event("keydown", %{"key" => @down_keycode}, socket) do
+  def handle_event("cycle_history", %{"key" => @down_keycode}, socket) do
     %{history_counter: counter, history: history} = socket.assigns
     {input_value, new_counter} = get_next_history_entry(history, counter)
     new_caret_position = String.length(input_value)
@@ -86,7 +86,7 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
      )}
   end
 
-  def handle_event("keydown", _key, socket) do
+  def handle_event("reset_history", _key, socket) do
     {:noreply, assign(socket, history_counter: -1, input_value: "")}
   end
 

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -9,9 +9,6 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
   import ElixirConsoleWeb.ConsoleLive.Helpers
   alias ElixirConsole.Autocomplete
 
-  @up_keycode "ArrowUp"
-  @down_keycode "ArrowDown"
-
   def mount(socket) do
     {:ok,
      assign(
@@ -55,7 +52,7 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
     end
   end
 
-  def handle_event("cycle_history", %{"key" => @up_keycode}, socket) do
+  def handle_event("cycle_history_up", _params, socket) do
     %{history_counter: counter, history: history} = socket.assigns
     {input_value, new_counter} = get_previous_history_entry(history, counter)
     new_caret_position = String.length(input_value)
@@ -68,7 +65,7 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
      )}
   end
 
-  def handle_event("cycle_history", %{"key" => @down_keycode}, socket) do
+  def handle_event("cycle_history_down", _params, socket) do
     %{history_counter: counter, history: history} = socket.assigns
     {input_value, new_counter} = get_next_history_entry(history, counter)
     new_caret_position = String.length(input_value)

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -9,7 +9,6 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
   import ElixirConsoleWeb.ConsoleLive.Helpers
   alias ElixirConsole.Autocomplete
 
-  @tab_keycode "Tab"
   @up_keycode "ArrowUp"
   @down_keycode "ArrowDown"
 
@@ -28,11 +27,7 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
 
   defp ensure_number(value), do: String.to_integer(value)
 
-  def handle_event(
-        "suggest",
-        %{"key" => @tab_keycode, "value" => value, "caret_position" => caret_position},
-        socket
-      ) do
+  def handle_event("suggest", %{"value" => value, "caret_position" => caret_position}, socket) do
     %{bindings: bindings} = socket.assigns
 
     # When testing this event using render_keydown/up, even if the metadata is defined as a number,

--- a/lib/elixir_console_web/live/console_live/command_input_component.html.leex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.html.leex
@@ -8,7 +8,6 @@
       autocomplete="off"
       autofocus
       name="command"
-      phx-keydown="keydown"
       phx-target="#command_input"
       phx-hook="CommandInput"
       data-input_value="<%= @input_value %>"

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -103,7 +103,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-      render_hook(input, :suggest, %{"key" => "Tab", "value" => "Enum.co", "caret_position" => 7})
+      render_hook(input, :suggest, %{"value" => "Enum.co", "caret_position" => 7})
 
       html = render(view)
 
@@ -114,12 +114,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-
-      render_hook(input, :suggest, %{
-        "key" => "Tab",
-        "value" => "Enum.conc",
-        "caret_position" => 9
-      })
+      render_hook(input, :suggest, %{"value" => "Enum.conc", "caret_position" => 9})
 
       html = render(view)
 
@@ -133,12 +128,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-
-      render_hook(input, :suggest, %{
-        "key" => "Tab",
-        "value" => "Enum.co([1,2]) - 2",
-        "caret_position" => 7
-      })
+      render_hook(input, :suggest, %{"value" => "Enum.co([1,2]) - 2", "caret_position" => 7})
 
       html = render(view)
 
@@ -151,11 +141,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       input = element(view, "#command_input input")
 
       html =
-        render_hook(input, :suggest, %{
-          "key" => "Tab",
-          "value" => "Enum.conc([1,2], [3])",
-          "caret_position" => 9
-        })
+        render_hook(input, :suggest, %{"value" => "Enum.conc([1,2], [3])", "caret_position" => 9})
 
       assert html =~ ~r/\<input .* data-input_value\="Enum.concat\(\[1,2\], \[3\]\)"/
       assert html =~ ~r/\<input .* data-caret_position\="11"/

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -103,7 +103,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-      render_keydown(input, %{"key" => "Tab", "value" => "Enum.co", "caret_position" => 7})
+      render_hook(input, :keydown, %{"key" => "Tab", "value" => "Enum.co", "caret_position" => 7})
 
       html = render(view)
 
@@ -114,7 +114,12 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-      render_keydown(input, %{"key" => "Tab", "value" => "Enum.conc", "caret_position" => 9})
+
+      render_hook(input, :keydown, %{
+        "key" => "Tab",
+        "value" => "Enum.conc",
+        "caret_position" => 9
+      })
 
       html = render(view)
 
@@ -129,7 +134,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
 
       input = element(view, "#command_input input")
 
-      render_keydown(input, %{
+      render_hook(input, :keydown, %{
         "key" => "Tab",
         "value" => "Enum.co([1,2]) - 2",
         "caret_position" => 7
@@ -146,7 +151,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       input = element(view, "#command_input input")
 
       html =
-        render_keydown(input, %{
+        render_hook(input, :keydown, %{
           "key" => "Tab",
           "value" => "Enum.conc([1,2], [3])",
           "caret_position" => 9

--- a/test/elixir_console_web/live/console_live_test.exs
+++ b/test/elixir_console_web/live/console_live_test.exs
@@ -103,7 +103,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       {:ok, view, _html} = live(conn, "/")
 
       input = element(view, "#command_input input")
-      render_hook(input, :keydown, %{"key" => "Tab", "value" => "Enum.co", "caret_position" => 7})
+      render_hook(input, :suggest, %{"key" => "Tab", "value" => "Enum.co", "caret_position" => 7})
 
       html = render(view)
 
@@ -115,7 +115,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
 
       input = element(view, "#command_input input")
 
-      render_hook(input, :keydown, %{
+      render_hook(input, :suggest, %{
         "key" => "Tab",
         "value" => "Enum.conc",
         "caret_position" => 9
@@ -134,7 +134,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
 
       input = element(view, "#command_input input")
 
-      render_hook(input, :keydown, %{
+      render_hook(input, :suggest, %{
         "key" => "Tab",
         "value" => "Enum.co([1,2]) - 2",
         "caret_position" => 7
@@ -151,7 +151,7 @@ defmodule ElixirConsoleWeb.ConsoleLiveTest do
       input = element(view, "#command_input input")
 
       html =
-        render_hook(input, :keydown, %{
+        render_hook(input, :suggest, %{
           "key" => "Tab",
           "value" => "Enum.conc([1,2], [3])",
           "caret_position" => 9


### PR DESCRIPTION
This is a refactor to separate the events sent when different keys are pressed.
I meant to also reduce the number of events sent by not sending a reset-input event everytime a different key in pressed but it required more work than expected so I'll leave it to a follow up PR