### PR TITLE
Only reset history counter when executing a command

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -37,8 +37,6 @@ Hooks.CommandInput = {
         this.pushEventTo('#commandInput', 'cycle_history_up');
       } else if (e.code === 'ArrowDown') {
         this.pushEventTo('#commandInput', 'cycle_history_down');
-      } else {
-        this.pushEventTo('#commandInput', 'reset_history', {});
       }
     });
   },

--- a/lib/elixir_console_web/live/console_live/command_input_component.ex
+++ b/lib/elixir_console_web/live/console_live/command_input_component.ex
@@ -78,13 +78,15 @@ defmodule ElixirConsoleWeb.ConsoleLive.CommandInputComponent do
      )}
   end
 
-  def handle_event("reset_history", _key, socket) do
-    {:noreply, assign(socket, history_counter: -1, input_value: "")}
-  end
-
   def handle_event("execute", %{"command" => command}, socket) do
     send(self(), {:execute_command, command})
-    {:noreply, push_event(socket, "reset", %{})}
+
+    socket =
+      socket
+      |> assign(history_counter: -1, input_value: "")
+      |> push_event("reset", %{})
+
+    {:noreply, socket}
   end
 
   defp get_previous_history_entry([], _counter), do: {"", 0}


### PR DESCRIPTION
This helps reducing considerably the events sent through the socket as
we don't need to send messages anymore when a different key is pressed.

This changes the current behavior slightly.
Previously if I was cycling through the history and pressed any key,
even keys like shift or cmd, it would reset the history and using up
arrow after that would start from the begining.
Now we continue from the same position we were.

I think this new behavior is not worse than what we had and it's definitely better when hitting keys that shouldn't affect the history, like non printable keys.
Overall we're sending events only when clear user actions are performed and no extra events to keep things in sync.